### PR TITLE
Pylint 2.0.0 and a little bit of housekeeping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,20 +36,18 @@ matrix:
       env: TOXENV=py36-examples
     - python: 3.6
       env: TOXENV=nocmk
-# disabling Bandit run in Travis pending resolution of https://bugs.launchpad.net/bandit/+bug/1749603
-#    - python: 3.6
-#      env: TOXENV=bandit
+    - python: 3.6
+      env: TOXENV=bandit
     - python: 3.6
       env: TOXENV=doc8
     - python: 3.6
       env: TOXENV=docs
     - python: 3.6
       env: TOXENV=readme
-# pending reorg of deserialize_header
-#    - python: 3.6
-#      env: TOXENV=flake8
-#    - python: 3.6
-#      env: TOXENV=pylint
+    - python: 3.6
+      env: TOXENV=flake8
+    - python: 3.6
+      env: TOXENV=pylint
     - python: 3.6
       env: TOXENV=flake8-tests
     - python: 3.6

--- a/examples/src/pylintrc
+++ b/examples/src/pylintrc
@@ -2,8 +2,11 @@
 # Disabling messages that either we don't care about we intentionally break.
 #
 # C0103 : invalid-name (we prefer long, descriptive, names for examples)
+# C0330 : bad-continuation (we let black handle this)
+# C0412 : ungrouped-imports (we let isort handle this)
 # E1101 : no-member (breaks with attrs)
 # R0201 : no-self-use (interesting to keep in mind for later refactoring, but not blocking)
+# R0205 : useless-object-inheritance (we need to support Python 2, so no, not useless)
 # R0801 : duplicate-code (some examples may be similar)
 # R0903 : too-few-public-methods (does not allow value stores)
 # R0914 : too-many-locals (examples may sometimes have more locals defined for clarity than would be appropriate in code)
@@ -11,7 +14,7 @@
 # W0201 : attribute-defined-outside-init (breaks with attrs_post_init)
 # W0223 : abstract-method (throws false positives on io.BaseIO grandchildren)
 # W0621 : redefined-outer-name (we do this on purpose in multiple places)
-disable = C0103, E1101, R0201, R0801, R0903, R0914, R1705, W0201, W0223, W0621
+disable = C0103, C0330, C0412, E1101, R0201, R0205, R0801, R0903, R0914, R1705, W0201, W0223, W0621
 
 [BASIC]
 # Allow function names up to 50 characters

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -95,6 +95,7 @@ class KDFSuite(Enum):
         self.hash_algorithm = hash_algorithm
 
     def input_length(self, encryption):
+        # type: (EncryptionSuite) -> int
         """Determine the correct KDF input value length for this KDFSuite when used with
         a specific EncryptionSuite.
 
@@ -102,7 +103,6 @@ class KDFSuite(Enum):
         :type encryption: aws_encryption_sdk.identifiers.EncryptionSuite
         :rtype: int
         """
-        # type: (EncryptionSuite) -> bool
         if self._input_length is None:
             return encryption.data_key_length
 

--- a/src/aws_encryption_sdk/internal/formatting/deserialize.py
+++ b/src/aws_encryption_sdk/internal/formatting/deserialize.py
@@ -105,14 +105,14 @@ def _verified_algorithm_from_id(algorithm_id):
     :raises NotSupportedError: if unsupported algorithm ID is received
     """
     try:
-        alg = AlgorithmSuite.get_by_id(algorithm_id)
+        algorithm_suite = AlgorithmSuite.get_by_id(algorithm_id)
     except KeyError as error:
         raise UnknownIdentityError('Unknown algorithm {}'.format(algorithm_id), error)
 
-    if not alg.allowed:
-        raise NotSupportedError('Unsupported algorithm: {}'.format(alg))
+    if not algorithm_suite.allowed:
+        raise NotSupportedError('Unsupported algorithm: {}'.format(algorithm_suite))
 
-    return alg
+    return algorithm_suite
 
 
 def _deserialize_encrypted_data_keys(stream):
@@ -183,21 +183,21 @@ def _verified_content_aad_length(content_aad_length):
     return 0
 
 
-def _verified_iv_length(iv_length, algorithm):
+def _verified_iv_length(iv_length, algorithm_suite):
     # type: (int, AlgorithmSuite) -> int
     """Verify an IV length for an algorithm suite.
 
     :param int iv_length: IV length to verify
-    :param AlgorithmSuite algorithm: Algorithm suite to verify against
+    :param AlgorithmSuite algorithm_suite: Algorithm suite to verify against
     :return: IV length
     :rtype: int
     :raises SerializationError: if IV length does not match algorithm suite
     """
-    if iv_length != algorithm.iv_len:
+    if iv_length != algorithm_suite.iv_len:
         raise SerializationError(
             'Specified IV length ({length}) does not match algorithm IV length ({algorithm})'.format(
                 length=iv_length,
-                algorithm=algorithm
+                algorithm=algorithm_suite
             )
         )
 

--- a/src/aws_encryption_sdk/internal/utils/__init__.py
+++ b/src/aws_encryption_sdk/internal/utils/__init__.py
@@ -132,7 +132,7 @@ def prepare_data_keys(primary_master_key, master_keys, algorithm, encryption_con
 try:
     _FILE_TYPE = file  # Python 2
 except NameError:
-    _FILE_TYPE = io.IOBase  # Python 3 # pylint: disable=invalid-name
+    _FILE_TYPE = io.IOBase  # Python 3 pylint: disable=invalid-name
 
 
 def prep_stream_data(data):

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -124,10 +124,19 @@ class _EncryptionStream(io.IOBase):
     # def _config_class(self):
     #     Configuration class for this class
 
-    line_length = LINE_LENGTH
+    line_length = LINE_LENGTH  # type: int
+    config = None  # type: _ClientConfig
+    bytes_read = None  # type: int
+    output_buffer = None  # type: bytes
+    _message_prepped = None  # type: bool
+    source_stream = None
+    _stream_length = None  # type: int
 
     def __new__(cls, **kwargs):
-        """Patch for abstractmethod-like enforcement in io.IOBase grandchildren."""
+        """Perform necessary handling for _EncryptionStream instances that should be
+        applied to all children.
+        """
+        # Patch for abstractmethod-like enforcement in io.IOBase grandchildren.
         if (
                 not (hasattr(cls, '_read_bytes') and callable(cls._read_bytes))
                 or not (hasattr(cls, '_prep_message') and callable(cls._read_bytes))

--- a/src/pylintrc
+++ b/src/pylintrc
@@ -1,14 +1,17 @@
 [MESSAGE CONTROL]
 # Disabling messages that either we don't care about we intentionally break.
 #
+# C0330 : bad-continuation (we let black handle this)
+# C0412 : ungrouped-imports (we let isort handle this)
 # E1101 : no-member (breaks with attrs)
 # R0201 : no-self-use (interesting to keep in mind for later refactoring, but not blocking)
+# R0205 : useless-object-inheritance (we need to support Python 2, so no, not useless)
 # R0903 : too-few-public-methods (does not allow value stores)
 # R1705 : no-else-return (we omit this on purpose for brevity where it would add no value)
 # W0201 : attribute-defined-outside-init (breaks with attrs_post_init)
 # W0223 : abstract-method (throws false positives on io.BaseIO grandchildren)
 # W0621 : redefined-outer-name (we do this on purpose in multiple places)
-disable = E1101, R0201, R0903, R1705, W0201, W0223, W0621
+disable = C0330, C0412, E1101, R0201, R0205, R0903, R1705, W0201, W0223, W0621
 
 [BASIC]
 # Allow function names up to 50 characters

--- a/test/pylintrc
+++ b/test/pylintrc
@@ -4,9 +4,12 @@
 #
 # C0103 : invalid-name (we prefer long, descriptive, names for tests)
 # C0111 : missing-docstring (we don't write docstrings for tests)
+# C0330 : bad-continuation (we let black handle this)
+# C0412 : ungrouped-imports (we let isort handle this)
 # E0110 : abstract-class-instantiated (we do this on purpose to test that they are enforced)
 # E1101 : no-member (raised on patched objects with mock checks)
 # R0201 : no-self-use (common pattern when using unittest: can be enabled once all tests are refactored to pytest)
+# R0205 : useless-object-inheritance (we need to support Python 2, so no, not useless)
 # R0801 : duplicate-code (unit tests for similar things tend to be similar)
 # R0902 : too-many-instance-attributes (common pattern when using unittest: can be enabled once all tests are refactored to pytest)
 # R0903 : too-few-public-methods (common when setting up mock classes)
@@ -18,7 +21,7 @@
 # W0223 : abstract-method (we do this on purpose to test that they are enforced)
 # W0621 : redefined-outer-name (raised when using pytest-mock)
 # W0613 : unused-argument (raised when patches are needed but not called)
-disable = C0103, C0111, E0110, E1101, R0201, R0801, R0902, R0903, R0904, R0914, R0915, W0201, W0212, W0223, W0621, W0613
+disable = C0103, C0111, C0330, C0412, E0110, E1101, R0201, R0205, R0801, R0902, R0903, R0904, R0914, R0915, W0201, W0212, W0223, W0621, W0613
 
 [VARIABLES]
 additional-builtins = raw_input

--- a/test/unit/test_caches.py
+++ b/test/unit/test_caches.py
@@ -117,7 +117,7 @@ VALUES['cache_ids'] = {
             'components': {
                 'partition_name': VALUES['basic']['partition_name'],
                 'algorithm': Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-                'encrypted_data_keys': set([entry['key'] for entry in VALUES['basic']['encrypted_data_keys']]),
+                'encrypted_data_keys': {entry['key'] for entry in VALUES['basic']['encrypted_data_keys']},
                 'encryption_context': VALUES['basic']['encryption_context']['full']['raw']
             },
             'id': b'+rtwUe38CGnczGmYu12iqGWHIyDyZ44EvYQ4S6ACmsgS8VaEpiw0RTGpDk6Z/7YYN/jVHOAcNKDyCNP8EmstFg=='

--- a/test/unit/test_deserialize.py
+++ b/test/unit/test_deserialize.py
@@ -20,7 +20,7 @@ import pytest
 import six
 
 from aws_encryption_sdk.exceptions import NotSupportedError, SerializationError, UnknownIdentityError
-from aws_encryption_sdk.identifiers import Algorithm
+from aws_encryption_sdk.identifiers import AlgorithmSuite
 import aws_encryption_sdk.internal.formatting.deserialize
 from aws_encryption_sdk.internal.structures import EncryptedData
 from .test_values import VALUES
@@ -108,7 +108,7 @@ class TestDeserialize(unittest.TestCase):
             stream = io.BytesIO(VALUES['serialized_header_invalid_version'])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
 
-    @patch('aws_encryption_sdk.internal.formatting.deserialize.Algorithm.get_by_id')
+    @patch('aws_encryption_sdk.internal.formatting.deserialize.AlgorithmSuite.get_by_id')
     def test_deserialize_header_unsupported_data_encryption_algorithm(self, mock_algorithm_get):
         """Validate that the deserialize_header function behaves
             as expected for an unsupported/disallowed algorithm.
@@ -120,7 +120,7 @@ class TestDeserialize(unittest.TestCase):
             stream = io.BytesIO(VALUES['serialized_header_disallowed_algorithm'])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
 
-    @patch('aws_encryption_sdk.internal.formatting.deserialize.Algorithm.get_by_id')
+    @patch('aws_encryption_sdk.internal.formatting.deserialize.AlgorithmSuite.get_by_id')
     def test_deserialize_header_unknown_data_encryption_algorithm(self, mock_algorithm_get):
         """Validate that the deserialize_header function behaves
             as expected for an unknown algorithm.
@@ -202,7 +202,7 @@ class TestDeserialize(unittest.TestCase):
         stream = io.BytesIO(VALUES['serialized_header_auth'])
         test = aws_encryption_sdk.internal.formatting.deserialize.deserialize_header_auth(
             stream=stream,
-            algorithm=Algorithm.AES_256_GCM_IV12_TAG16
+            algorithm=AlgorithmSuite.AES_256_GCM_IV12_TAG16
         )
         assert test == VALUES['deserialized_header_auth_block']
 
@@ -345,7 +345,7 @@ class TestDeserialize(unittest.TestCase):
             )
 
     def test_deserialize_wrapped_key_symmetric_wrapping_algorithm_iv_len_mismatch(self):
-        with six.assertRaisesRegex(self, SerializationError, 'Wrapping Algorithm mismatch for wrapped data key'):
+        with six.assertRaisesRegex(self, SerializationError, 'Wrapping AlgorithmSuite mismatch for wrapped data key'):
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_wrapped_key(
                 wrapping_algorithm=self.mock_wrapping_algorithm,
                 wrapping_key_id=VALUES['wrapped_keys']['raw']['key_info'],


### PR DESCRIPTION
*Issue #, if available:* #65 #17 #49 

*Description of changes:*
In the process of updating our code to comply with the new checks in Pylint 2.0.0, I made the additional changes:

- Finally got around to breaking `deserialize_header` logic out into component functions.
- Above enabled turning on flake8 and pylint runs in Travis.
- Turned on bandit run in Travis. 1.4.1 (or whatever the next version will be) still is not published, but we're pulling from their GitHub head for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
