### PR TITLE
Fix stream handler implementation of readable()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+1.3.6 -- 2018-08-29
+===================
+
+Bugfixes
+--------
+* :class:`StreamEncryptor` and :class:`StreamDecryptor` should always report as readable if they are open.
+  `#73 <https://github.com/aws/aws-encryption-sdk-python/issues/73>`_
+
 1.3.5 -- 2018-08-01
 ===================
 * Move the ``aws-encryption-sdk-python`` repository from ``awslabs`` to ``aws``.
@@ -18,7 +26,7 @@ Maintenance
 -----------
 * New minimum pytest version 3.3.1 to avoid bugs in 3.3.0
   `#32 <https://github.com/aws/aws-encryption-sdk-python/issues/32>`_
-* New minimum attrs version 17.4.0 to allow use of `converter` rather than `convert`
+* New minimum attrs version 17.4.0 to allow use of ``converter`` rather than ``convert``
   `#39 <https://github.com/aws/aws-encryption-sdk-python/issues/39>`_
 * Algorithm Suites are modeled as collections of sub-suites now
   `#36 <https://github.com/aws/aws-encryption-sdk-python/pull/36>`_

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.primitives.kdf import hkdf
 
 from aws_encryption_sdk.exceptions import InvalidAlgorithmError
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 USER_AGENT_SUFFIX = "AwsEncryptionSdkPython/{}".format(__version__)
 
 

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -193,6 +193,15 @@ class _EncryptionStream(io.IOBase):
             _LOGGER.exception("Error on closing")
         return False
 
+    def readable(self):
+        # () -> bool
+        """Return `True` if the stream can be read from.
+
+        :rtype: bool
+        """
+        # Open streams are currently always readable.
+        return not self.closed
+
     def read(self, b=None):
         """Returns either the requested number of bytes or the entire stream.
 

--- a/test/functional/test_f_aws_encryption_sdk_client.py
+++ b/test/functional/test_f_aws_encryption_sdk_client.py
@@ -574,3 +574,24 @@ def test_decrypt_oneshot_no_seek_input():
     ciphertext_no_seek = NoSeekBytesIO(ciphertext)
     decrypted, _header = aws_encryption_sdk.decrypt(source=ciphertext_no_seek, key_provider=key_provider)
     assert decrypted == VALUES["plaintext_128"]
+
+
+def test_stream_encryptor_readable():
+    """Verify that open StreamEncryptor instances report as readable."""
+    key_provider = fake_kms_key_provider()
+    plaintext = io.BytesIO(VALUES["plaintext_128"])
+    with aws_encryption_sdk.StreamEncryptor(source=plaintext, key_provider=key_provider) as handler:
+        assert handler.readable()
+        handler.read()
+    assert not handler.readable()
+
+
+def test_stream_decryptor_readable():
+    """Verify that open StreamEncryptor instances report as readable."""
+    key_provider = fake_kms_key_provider()
+    plaintext = io.BytesIO(VALUES["plaintext_128"])
+    ciphertext, _header = aws_encryption_sdk.encrypt(source=plaintext, key_provider=key_provider)
+    with aws_encryption_sdk.StreamDecryptor(source=ciphertext, key_provider=key_provider) as handler:
+        assert handler.readable()
+        handler.read()
+    assert not handler.readable()


### PR DESCRIPTION
*Issue #, if available:* #73 

*Description of changes:*
`StreamEncryptor` and `StreamDecryptor` should always report as readable if they are open.

We had previously been inheriting this from `io.BaseIO`, but it turns out that this was not implementing the behavior we expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
