### PR TITLE
fix KMSMasterKeyProvider to determine the default region before trying to create the requested master keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog
 *********
 
+1.3.7 -- 2018-09-17
+===================
+
+Bugfixes
+--------
+
+* Fix KMSMasterKeyProvider to determine the default region before trying to create the requested master keys.
+  `#83 <https://github.com/aws/aws-encryption-sdk-python/issues/83>`_
+
+
 1.3.6 -- 2018-09-04
 ===================
 

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.primitives.kdf import hkdf
 
 from aws_encryption_sdk.exceptions import InvalidAlgorithmError
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 USER_AGENT_SUFFIX = "AwsEncryptionSdkPython/{}".format(__version__)
 
 

--- a/src/aws_encryption_sdk/key_providers/kms.py
+++ b/src/aws_encryption_sdk/key_providers/kms.py
@@ -116,8 +116,7 @@ class KMSMasterKeyProvider(MasterKeyProvider):
     def _process_config(self):
         """Traverses the config and adds master keys and regional clients as needed."""
         self._user_agent_adding_config = botocore.config.Config(user_agent_extra=USER_AGENT_SUFFIX)
-        if self.config.key_ids:
-            self.add_master_keys_from_list(self.config.key_ids)
+
         if self.config.region_names:
             self.add_regional_clients_from_list(self.config.region_names)
             self.default_region = self.config.region_names[0]
@@ -125,6 +124,9 @@ class KMSMasterKeyProvider(MasterKeyProvider):
             self.default_region = self.config.botocore_session.get_config_variable("region")
             if self.default_region is not None:
                 self.add_regional_client(self.default_region)
+
+        if self.config.key_ids:
+            self.add_master_keys_from_list(self.config.key_ids)
 
     def add_regional_client(self, region_name):
         """Adds a regional client for the specified region if it does not already exist.

--- a/test/unit/test_providers_kms_master_key_provider.py
+++ b/test/unit/test_providers_kms_master_key_provider.py
@@ -25,6 +25,13 @@ from aws_encryption_sdk.key_providers.kms import KMSMasterKey, KMSMasterKeyProvi
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
+def test_init_with_regionless_key_ids_and_region_names():
+    key_ids = ("alias/key_1",)
+    region_names = ("test-reqion-1",)
+    provider = KMSMasterKeyProvider(region_names=region_names, key_ids=key_ids)
+    assert provider.master_key("alias/key_1").config.client.meta.region_name == region_names[0]
+
+
 class TestKMSMasterKeyProvider(unittest.TestCase):
     def setUp(self):
         self.mock_botocore_session_patcher = patch("aws_encryption_sdk.key_providers.kms.botocore.session.Session")

--- a/test/unit/test_providers_kms_master_key_provider.py
+++ b/test/unit/test_providers_kms_master_key_provider.py
@@ -27,7 +27,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 def test_init_with_regionless_key_ids_and_region_names():
     key_ids = ("alias/key_1",)
-    region_names = ("test-reqion-1",)
+    region_names = ("test-region-1",)
     provider = KMSMasterKeyProvider(region_names=region_names, key_ids=key_ids)
     assert provider.master_key("alias/key_1").config.client.meta.region_name == region_names[0]
 


### PR DESCRIPTION
*Issue #, if available:* #83

*Description of changes:*
Fix KMSMasterKeyProvider to determine the default region before trying to create the requested master keys.

We were previously trying to build the master keys *before* finding the default region, which would break any time a requested key ID was not a full Arn.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
