### PR TITLE
First draft of keyrings for Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ __pycache__
 
 # PyCharm
 .idea/
+venv/
 
 # Tox
 .tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ boto3>=1.4.4
 cryptography>=1.8.1
 attrs>=17.4.0
 wrapt>=1.10.11
-zope.interface>=4.5.0
 six>=1.11.0
 enum34; python_version < '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ boto3>=1.4.4
 cryptography>=1.8.1
 attrs>=17.4.0
 wrapt>=1.10.11
+zope.interface>=4.5.0
+six>=1.11.0
+enum34; python_version < '3.4'

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,4 +51,4 @@ force_grid_wrap = 0
 combine_as_imports = True
 not_skip = __init__.py
 known_first_party = aws_encryption_sdk
-known_third_party = attr,awses_test_vectors,basic_encryption,basic_file_encryption_with_multiple_providers,basic_file_encryption_with_raw_key_provider,boto3,botocore,cryptography,data_key_caching_basic,integration_test_utils,mock,pytest,pytest_mock,setuptools,six,typing,wrapt
+known_third_party = attr,aws_encryption_sdk,aws_encryption_sdk_decrypt_oracle,awses_test_vectors,basic_encryption,basic_file_encryption_with_multiple_providers,basic_file_encryption_with_raw_key_provider,boto3,botocore,chalice,cryptography,data_key_caching_basic,integration_test_utils,mock,pytest,pytest_mock,requests,setuptools,six,wrapt,zope

--- a/src/aws_encryption_sdk/keyrings/__init__.py
+++ b/src/aws_encryption_sdk/keyrings/__init__.py
@@ -14,65 +14,44 @@
 
 .. versionadded:: 1.4.0
 """
-from zope.interface import Interface, implementer
+import abc
+
+import six
 
 from aws_encryption_sdk.structures import DataKeyMaterials
 
 
-class KeyringPublicInterface(Interface):
-    """The public interface that all keyrings expose."""
+@six.add_metaclass(abc.ABCMeta)
+class Keyring(object):
+    """Parent class for all keyrings."""
 
-    def on_encrypt(self, data_key_materials):
-        # type: (DataKeyMaterials) -> DataKeyMaterials
-        """Complete a data key materials for use on encrypt.
-
-        :param DataKeyMaterials data_key_materials: Data key materials to start with
-        :return: Data key materials with any applicable materials added
-        :rtype: DataKeyMaterials
-        """
-
-    def on_decrypt(self, data_key_materials):
-        # type: (DataKeyMaterials) -> DataKeyMaterials
-        """Complete a data key materials for use on decrypt.
-
-        :param DataKeyMaterials data_key_materials:
-        :return: Data key materials with any applicable materials added
-        :rtype: DataKeyMaterials
-        """
-
-
-class KeyringPrivateInterface(Interface):
-    """The private interface that every ``Keyring`` child must implement.
-
-    .. note::
-
-        This is the interface that keyrings subclassing from :class:`Keyring`
-        should be implementing.
-    """
-
+    @abc.abstractmethod
     def _on_encrypt(self, data_key_materials):
         # type: (DataKeyMaterials) -> DataKeyMaterials
         """Complete a data key materials for use on encrypt.
 
+        .. note::
+
+            Children of :class:`Keyring` must implement this method.
+
         :param DataKeyMaterials data_key_materials: Data key materials to start with
         :return: Data key materials with any applicable materials added
         :rtype: DataKeyMaterials
         """
 
+    @abc.abstractmethod
     def _on_decrypt(self, data_key_materials):
         # type: (DataKeyMaterials) -> DataKeyMaterials
         """Complete a data key materials for use on decrypt.
+
+        .. note::
+
+            Children of :class:`Keyring` must implement this method.
 
         :param DataKeyMaterials data_key_materials:
         :return: Data key materials with any applicable materials added
         :rtype: DataKeyMaterials
         """
-
-
-@implementer(KeyringPublicInterface)
-@implementer(KeyringPrivateInterface)
-class Keyring(object):
-    """Parent class for all keyrings."""
 
     def on_encrypt(self, data_key_materials):
         # type: (DataKeyMaterials) -> DataKeyMaterials

--- a/src/aws_encryption_sdk/keyrings/__init__.py
+++ b/src/aws_encryption_sdk/keyrings/__init__.py
@@ -1,0 +1,106 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Interfaces and base class for keyrings.
+
+.. versionadded:: 1.4.0
+"""
+from zope.interface import Interface, implementer
+
+from aws_encryption_sdk.structures import DataKeyMaterials
+
+
+class KeyringPublicInterface(Interface):
+    """The public interface that all keyrings expose."""
+
+    def on_encrypt(self, data_key_materials):
+        # type: (DataKeyMaterials) -> DataKeyMaterials
+        """Complete a data key materials for use on encrypt.
+
+        :param DataKeyMaterials data_key_materials: Data key materials to start with
+        :return: Data key materials with any applicable materials added
+        :rtype: DataKeyMaterials
+        """
+
+    def on_decrypt(self, data_key_materials):
+        # type: (DataKeyMaterials) -> DataKeyMaterials
+        """Complete a data key materials for use on decrypt.
+
+        :param DataKeyMaterials data_key_materials:
+        :return: Data key materials with any applicable materials added
+        :rtype: DataKeyMaterials
+        """
+
+
+class KeyringPrivateInterface(Interface):
+    """The private interface that every ``Keyring`` child must implement.
+
+    .. note::
+
+        This is the interface that keyrings subclassing from :class:`Keyring`
+        should be implementing.
+    """
+
+    def _on_encrypt(self, data_key_materials):
+        # type: (DataKeyMaterials) -> DataKeyMaterials
+        """Complete a data key materials for use on encrypt.
+
+        :param DataKeyMaterials data_key_materials: Data key materials to start with
+        :return: Data key materials with any applicable materials added
+        :rtype: DataKeyMaterials
+        """
+
+    def _on_decrypt(self, data_key_materials):
+        # type: (DataKeyMaterials) -> DataKeyMaterials
+        """Complete a data key materials for use on decrypt.
+
+        :param DataKeyMaterials data_key_materials:
+        :return: Data key materials with any applicable materials added
+        :rtype: DataKeyMaterials
+        """
+
+
+@implementer(KeyringPublicInterface)
+@implementer(KeyringPrivateInterface)
+class Keyring(object):
+    """Parent class for all keyrings."""
+
+    def on_encrypt(self, data_key_materials):
+        # type: (DataKeyMaterials) -> DataKeyMaterials
+        """Complete a data key materials for use on encrypt.
+
+        :param DataKeyMaterials data_key_materials: Data key materials to start with
+        :return: Data key materials with any applicable materials added
+        :rtype: DataKeyMaterials
+        """
+        if data_key_materials.plaintext_data_key is None and data_key_materials.encrypted_data_keys:
+            raise Exception(
+                "TODO: " "On encrypt, data key materials cannot contain encrypted data keys but no plaintext data key."
+            )
+
+        return self._on_encrypt(data_key_materials)
+
+    def on_decrypt(self, data_key_materials):
+        # type: (DataKeyMaterials) -> DataKeyMaterials
+        """Complete a data key materials for use on decrypt.
+
+        :param DataKeyMaterials data_key_materials:
+        :return: Data key materials with any applicable materials added
+        :rtype: DataKeyMaterials
+        """
+        if data_key_materials.plaintext_data_key is not None:
+            return data_key_materials
+
+        if not data_key_materials.encrypted_data_keys:
+            raise Exception("TODO: " "No encrypted data keys found.")
+
+        return self._on_decrypt(data_key_materials)

--- a/src/aws_encryption_sdk/keyrings/master_key.py
+++ b/src/aws_encryption_sdk/keyrings/master_key.py
@@ -1,0 +1,119 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Keyring that provides a translation layer between master key providers and keyrings.
+
+.. versionadded:: 1.4.0
+"""
+import attr
+
+from aws_encryption_sdk.exceptions import MasterKeyProviderError
+from aws_encryption_sdk.internal.utils import prepare_data_keys
+from aws_encryption_sdk.internal.utils.streams import ROStream
+from aws_encryption_sdk.key_providers.base import MasterKeyProvider
+from aws_encryption_sdk.keyrings import Keyring
+from aws_encryption_sdk.structures import DataKeyMaterials, RawDataKey
+
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Optional  # noqa pylint: disable=unused-import
+except ImportError:  # pragma: no cover
+    # We only actually need these imports when running the mypy checks
+    pass
+
+
+@attr.s
+class MasterKeyKeyring(Keyring):
+    """Keyring that provides a translation layer between master key providers and keyrings.
+
+    .. versionadded:: 1.4.0
+
+    :param MasterKeyProvider master_key_provider: Master key provider to use
+    """
+
+    master_key_provider = attr.ib(validator=attr.validators.instance_of(MasterKeyProvider))
+    _plaintext_rostream = None
+    _plaintext_length = None
+
+    def with_plaintext(self, plaintext_rostream, plaintext_length):
+        # type: (Optional[ROStream], Optional[int]) -> MasterKeyKeyring
+        """Build a new :class:`MasterKeyKeyring` with the provided plaintext information.
+
+        :param ROStream plaintext_rostream: Stream that provides read-only access to plaintext data
+        :param int plaintext_length: Length of plaintext data
+        :return: Master key keyring with plaintext information
+        :rtype: MasterKeyKeyring
+        """
+        new_keyring = MasterKeyKeyring(master_key_provider=self.master_key_provider)
+        new_keyring._plaintext_rostream = plaintext_rostream
+        new_keyring._plaintext_length = plaintext_length
+        return new_keyring
+
+    def _on_encrypt(self, data_key_materials):
+        # type: (DataKeyMaterials) -> DataKeyMaterials
+        """Complete a data key materials for use on encrypt.
+
+        :param DataKeyMaterials data_key_materials: Data key materials to start with
+        :return: Data key materials with any applicable materials added
+        :rtype: DataKeyMaterials
+        """
+
+        primary_master_key, master_keys = self.master_key_provider.master_keys_for_encryption(
+            encryption_context=data_key_materials.encryption_context,
+            # TODO: figure out how to pass through plaintext data...
+            plaintext_rostream=self._plaintext_rostream,
+            plaintext_length=self._plaintext_length,
+        )
+
+        if not master_keys:
+            raise MasterKeyProviderError("No Master Keys available from Master Key Provider")
+
+        if primary_master_key not in master_keys:
+            raise MasterKeyProviderError("Primary Master Key not in provided Master Keys")
+
+        data_encryption_key, encrypted_data_keys = prepare_data_keys(
+            primary_master_key=primary_master_key,
+            master_keys=master_keys,
+            algorithm=data_key_materials.algorithm_suite,
+            encryption_context=data_key_materials.encryption_context,
+        )
+
+        return DataKeyMaterials(
+            algorithm_suite=data_key_materials.algorithm_suite,
+            encryption_context=data_key_materials.encryption_context,
+            plaintext_data_key=RawDataKey(
+                key_provider=data_encryption_key.key_provider, data_key=data_encryption_key.data_key
+            ),
+            encrypted_data_keys=set(encrypted_data_keys),
+        )
+
+    def _on_decrypt(self, data_key_materials):
+        # type: (DataKeyMaterials) -> DataKeyMaterials
+        """Complete a data key materials for use on decrypt.
+
+        :param DataKeyMaterials data_key_materials:
+        :return: Data key materials with any applicable materials added
+        :rtype: DataKeyMaterials
+        """
+        plaintext_data_key = self.master_key_provider.decrypt_data_key_from_list(
+            encrypted_data_keys=data_key_materials.encrypted_data_keys,
+            algorithm=data_key_materials.algorithm_suite,
+            encryption_context=data_key_materials.encryption_context,
+        )
+
+        return DataKeyMaterials(
+            algorithm_suite=data_key_materials.algorithm_suite,
+            encryption_context=data_key_materials.encryption_context,
+            plaintext_data_key=RawDataKey(
+                key_provider=plaintext_data_key.key_provider, data_key=plaintext_data_key.data_key
+            ),
+            encrypted_data_keys=set(data_key_materials.encrypted_data_keys),
+        )

--- a/test/unit/test_keyring.py
+++ b/test/unit/test_keyring.py
@@ -1,0 +1,28 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Test suite for ``aws_encryption_sdk.keyrings``"""
+import pytest
+
+from aws_encryption_sdk.keyrings import Keyring
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
+
+def test_interface_enforcement():
+    class BrokenKeyring(Keyring):
+        """This keyring does not implement the private interface."""
+
+    with pytest.raises(TypeError) as excinfo:
+        BrokenKeyring()
+
+    excinfo.match("Can't instantiate abstract class BrokenKeyring with abstract methods _on_decrypt, _on_encrypt")

--- a/tox.ini
+++ b/tox.ini
@@ -230,9 +230,11 @@ commands = {[testenv:isort]commands} -c
 basepython = python3
 deps =
     {[testenv:blacken]deps}
+    {[testenv:isort-seed]deps}
     {[testenv:isort]deps}
 commands =
     {[testenv:blacken]commands}
+    {[testenv:isort-seed]commands}
     {[testenv:isort]commands}
 
 [testenv:doc8]


### PR DESCRIPTION
*Description of changes:*

This is the first draft of when keyrings will look like in this client. I'm targeting a newly created feature branch because this is not yet ready to be merged into master.

This PR:
* introduces the required primitives that keyrings will handle
* introduces the base `Keyring` class and its interfaces
* updates `DefaultCryptographicMaterialsManager` to accept either a master key provider or a keyring
* adds a `MasterKeyKeyring` that provides a shim between master key providers and keyrings
  * This now contains the MK/P handling logic that was previously in the `DefaultCryptographicMaterialsManager`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
