### PR TITLE
standardize on manifest.json as the entry-point manifest for test vectors

### DIFF
--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/encrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/encrypt.py
@@ -239,5 +239,5 @@ class MessageEncryptionManifest(object):
         )
 
         root_writer(
-            "decrypt_message.json", json.dumps(decrypt_manifest.manifest_spec, indent=json_indent).encode(ENCODING)
+            "manifest.json", json.dumps(decrypt_manifest.manifest_spec, indent=json_indent).encode(ENCODING)
         )

--- a/test_vector_handlers/test/integration/commands/test_i_full_message_encrypt.py
+++ b/test_vector_handlers/test/integration/commands/test_i_full_message_encrypt.py
@@ -31,5 +31,5 @@ def test_full_message_cycle_canonical_full(tmpdir, full_message_encrypt_vectors)
     output_dir = tmpdir.join("output")
     full_message_encrypt.cli(["--output", str(output_dir), "--input", full_message_encrypt_vectors])
 
-    decrypt_manifest_file = output_dir.join("decrypt_message.json")
+    decrypt_manifest_file = output_dir.join("manifest.json")
     full_message_decrypt.cli(["--input", str(decrypt_manifest_file)])


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-encryption-sdk-test-vectors/issues/7

*Description of changes:*
This standardizes the entry-point manifest to the `manifest.json` name. Once we have the meta-manifest compatibility built, I would prefer to change the entry-point to always be a meta-manifest, but anything reading a manifest must be able to identify its type regardless.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
