### PR TITLE
Add support for SHA384 and SHA512 for use with RSA OAEP wrapping algorithms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 *********
 
+1.3.8 -- 2018-xx-xx
+===================
+
+Minor
+-----
+
+* Add support to remove clients from :ref:`KMSMasterKeyProvider` client cache if they fail to connect to endpoint.
+  `#86 <https://github.com/aws/aws-encryption-sdk-python/pull/86>`_
+* Add support for SHA384 and SHA512 for use with RSA OAEP wrapping algorithms.
+  `#56 <https://github.com/aws/aws-encryption-sdk-python/issues/56>`_
+
 1.3.7 -- 2018-09-20
 ===================
 

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -271,6 +271,8 @@ class WrappingAlgorithm(Enum):
     RSA_PKCS1 = (EncryptionType.ASYMMETRIC, rsa, padding.PKCS1v15, None, None)
     RSA_OAEP_SHA1_MGF1 = (EncryptionType.ASYMMETRIC, rsa, padding.OAEP, hashes.SHA1, padding.MGF1)
     RSA_OAEP_SHA256_MGF1 = (EncryptionType.ASYMMETRIC, rsa, padding.OAEP, hashes.SHA256, padding.MGF1)
+    RSA_OAEP_SHA384_MGF1 = (EncryptionType.ASYMMETRIC, rsa, padding.OAEP, hashes.SHA384, padding.MGF1)
+    RSA_OAEP_SHA512_MGF1 = (EncryptionType.ASYMMETRIC, rsa, padding.OAEP, hashes.SHA512, padding.MGF1)
 
     def __init__(self, encryption_type, algorithm, padding_type, padding_algorithm, padding_mgf):
         """Prepares new WrappingAlgorithm."""

--- a/test/functional/test_f_aws_encryption_sdk_client.py
+++ b/test/functional/test_f_aws_encryption_sdk_client.py
@@ -334,16 +334,19 @@ def test_encryption_cycle_raw_mkp(wrapping_algorithm, encryption_key_type, decry
 
 
 @pytest.mark.skipif(
-    not _mgf1_sha256_supported(), reason="MGF1-SHA256 not supported by this backend: OpenSSL required v1.0.2+"
+    not _mgf1_sha256_supported(), reason="MGF1-SHA2 not supported by this backend: OpenSSL required v1.0.2+"
 )
 @pytest.mark.parametrize(
-    "wrapping_algorithm, encryption_key_type, decryption_key_type",
+    "wrapping_algorithm",
     (
-        (WrappingAlgorithm.RSA_OAEP_SHA256_MGF1, EncryptionKeyType.PRIVATE, EncryptionKeyType.PRIVATE),
-        (WrappingAlgorithm.RSA_OAEP_SHA256_MGF1, EncryptionKeyType.PUBLIC, EncryptionKeyType.PRIVATE),
+        WrappingAlgorithm.RSA_OAEP_SHA256_MGF1,
+        WrappingAlgorithm.RSA_OAEP_SHA384_MGF1,
+        WrappingAlgorithm.RSA_OAEP_SHA512_MGF1,
     ),
 )
-def test_encryption_cycle_raw_mkp_openssl_102_plus(wrapping_algorithm, encryption_key_type, decryption_key_type):
+@pytest.mark.parametrize("encryption_key_type", (EncryptionKeyType.PUBLIC, EncryptionKeyType.PRIVATE))
+def test_encryption_cycle_raw_mkp_openssl_102_plus(wrapping_algorithm, encryption_key_type):
+    decryption_key_type = EncryptionKeyType.PRIVATE
     encrypting_key_provider = build_fake_raw_key_provider(wrapping_algorithm, encryption_key_type)
     decrypting_key_provider = build_fake_raw_key_provider(wrapping_algorithm, decryption_key_type)
     ciphertext, _ = aws_encryption_sdk.encrypt(

--- a/test/functional/test_f_xcompat.py
+++ b/test/functional/test_f_xcompat.py
@@ -57,6 +57,8 @@ _WRAPPING_ALGORITHM_MAP = {
             b"OAEP-MGF1": {
                 b"SHA-1": WrappingAlgorithm.RSA_OAEP_SHA1_MGF1,
                 b"SHA-256": WrappingAlgorithm.RSA_OAEP_SHA256_MGF1,
+                b"SHA-384": WrappingAlgorithm.RSA_OAEP_SHA384_MGF1,
+                b"SHA-512": WrappingAlgorithm.RSA_OAEP_SHA512_MGF1,
             },
         }
     ),


### PR DESCRIPTION
*Issue #, if available:* #56 

*Description of changes:*
Adds support for SHA384 and SHA512 for use with RSA OAEP wrapping algorithms and tests for same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
