### PR TITLE
add flake8-bugbear to flake8 check

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -118,6 +118,7 @@ deps =
     flake8-docstrings
     # https://github.com/JBKahn/flake8-print/pull/30
     flake8-print>=3.1.0
+    flake8-bugbear
 commands =
     flake8 src/aws_encryption_sdk/ setup.py
 


### PR DESCRIPTION
*Description of changes:*
I recently ran across [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear), and it seemed like a good thing to add to our linting checks. Turns out we're already compliant with all the checks, but it's another good set of guidelines to stick to.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
