### PR TITLE
Properly handle negative values to _EncryptionStream.read()

### DIFF
--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -209,6 +209,10 @@ class _EncryptionStream(io.IOBase):
         :returns: Processed (encrypted or decrypted) bytes from source stream
         :rtype: bytes
         """
+        # Any negative value for b is interpreted as a full read
+        if b is not None and b < 0:
+            b = None
+
         _LOGGER.debug("Stream read called, requesting %s bytes", b)
         output = io.BytesIO()
         if not self._message_prepped:

--- a/test/unit/test_streaming_client_encryption_stream.py
+++ b/test/unit/test_streaming_client_encryption_stream.py
@@ -47,7 +47,6 @@ class MockEncryptionStream(_EncryptionStream):
 
 
 class TestEncryptionStream(object):
-
     def _mock_key_provider(self):
         mock_key_provider = MagicMock()
         mock_key_provider.__class__ = MasterKeyProvider
@@ -226,7 +225,7 @@ class TestEncryptionStream(object):
 
         excinfo.match("I/O operation on closed file")
 
-    @pytest.mark.parametrize('bytes_to_read', range(1, 11))
+    @pytest.mark.parametrize("bytes_to_read", range(1, 11))
     def test_read_b(self, bytes_to_read):
         mock_stream = MockEncryptionStream(
             source=io.BytesIO(VALUES["data_128"]),
@@ -241,7 +240,8 @@ class TestEncryptionStream(object):
         assert test == data[:bytes_to_read]
         assert mock_stream.output_buffer == data[bytes_to_read:]
 
-    def test_read_all(self):
+    @pytest.mark.parametrize("bytes_to_read", (None, -1, -99))
+    def test_read_all(self, bytes_to_read):
         mock_stream = MockEncryptionStream(
             source=self.mock_source_stream, key_provider=self.mock_key_provider, mock_read_bytes=sentinel.read_bytes
         )
@@ -249,7 +249,7 @@ class TestEncryptionStream(object):
         mock_stream.output_buffer = b"1234567890"
         mock_stream.source_stream = MagicMock()
         type(mock_stream.source_stream).closed = PropertyMock(side_effect=(False, False, True))
-        test = mock_stream.read()
+        test = mock_stream.read(bytes_to_read)
         assert test == b"1234567890"
 
     def test_read_all_empty_source(self):

--- a/test/unit/test_streaming_client_encryption_stream.py
+++ b/test/unit/test_streaming_client_encryption_stream.py
@@ -13,11 +13,9 @@
 """Unit test suite for aws_encryption_sdk.streaming_client._EncryptionStream"""
 import copy
 import io
-import unittest
 
 import attr
 import pytest
-import six
 from mock import MagicMock, PropertyMock, call, patch, sentinel
 
 import aws_encryption_sdk.exceptions

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ commands =
     accept: {[testenv:base-command]commands} test/ -m accept
     examples: {[testenv:base-command]commands} examples/test/ -m examples
     all: {[testenv:base-command]commands} test/ examples/test/
+    manual: {[testenv:base-command]commands}
 
 # Verify that local tests work without environment variables present
 [testenv:nocmk]


### PR DESCRIPTION
*Issue #, if available:* #26 

*Description of changes:*
The actual fix was tiny. Most of this PR is refactoring the test class from unittest to pytest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
