### PR TITLE
Fix handling of partial reads

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,10 +8,12 @@ Changelog
 Minor
 -----
 
-* Add support to remove clients from :ref:`KMSMasterKeyProvider` client cache if they fail to connect to endpoint.
+* Add support to remove clients from :class:`KMSMasterKeyProvider` client cache if they fail to connect to endpoint.
   `#86 <https://github.com/aws/aws-encryption-sdk-python/pull/86>`_
 * Add support for SHA384 and SHA512 for use with RSA OAEP wrapping algorithms.
   `#56 <https://github.com/aws/aws-encryption-sdk-python/issues/56>`_
+* Fix ``streaming_client`` classes to properly interpret short reads in source streams.
+  `#24 <https://github.com/aws/aws-encryption-sdk-python/issues/24>`_
 
 1.3.7 -- 2018-09-20
 ===================

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ branch = True
 show_missing = True
 
 [tool:pytest]
+log_level = DEBUG
 markers =
     local: superset of unit and functional (does not require network access)
     unit: mark test as a unit test (does not require network access)

--- a/src/aws_encryption_sdk/internal/utils/__init__.py
+++ b/src/aws_encryption_sdk/internal/utils/__init__.py
@@ -23,6 +23,8 @@ from aws_encryption_sdk.identifiers import ContentAADString, ContentType
 from aws_encryption_sdk.internal.str_ops import to_bytes
 from aws_encryption_sdk.structures import EncryptedDataKey
 
+from .streams import InsistentReaderBytesIO
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -132,12 +134,14 @@ def prep_stream_data(data):
 
     :param data: Input data
     :returns: Prepared stream
-    :rtype: io.BytesIO
+    :rtype: InsistentReaderBytesIO
     """
     if isinstance(data, (six.string_types, six.binary_type)):
-        return io.BytesIO(to_bytes(data))
+        stream = io.BytesIO(to_bytes(data))
+    else:
+        stream = data
 
-    return data
+    return InsistentReaderBytesIO(stream)
 
 
 def source_data_key_length_check(source_data_key, algorithm):

--- a/src/aws_encryption_sdk/internal/utils/streams.py
+++ b/src/aws_encryption_sdk/internal/utils/streams.py
@@ -81,7 +81,12 @@ class InsistentReaderBytesIO(ObjectProxy):
         remaining_bytes = b
         data = io.BytesIO()
         while True:
-            chunk = to_bytes(self.__wrapped__.read(remaining_bytes))
+            try:
+                chunk = to_bytes(self.__wrapped__.read(remaining_bytes))
+            except ValueError:
+                if self.__wrapped__.closed:
+                    break
+                raise
 
             if not chunk:
                 break

--- a/src/aws_encryption_sdk/internal/utils/streams.py
+++ b/src/aws_encryption_sdk/internal/utils/streams.py
@@ -11,9 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Helper stream utility objects for AWS Encryption SDK."""
+import io
+
 from wrapt import ObjectProxy
 
 from aws_encryption_sdk.exceptions import ActionNotAllowedError
+from aws_encryption_sdk.internal.str_ops import to_bytes
 
 
 class ROStream(ObjectProxy):
@@ -56,3 +59,36 @@ class TeeStream(ObjectProxy):
         data = self.__wrapped__.read(b)
         self.__tee.write(data)
         return data
+
+
+class InsistentReaderBytesIO(ObjectProxy):
+    """Wrapper around a readable stream that insists on reading exactly the requested
+    number of bytes. It will keep trying to read bytes from the wrapped stream until
+    either the requested number of bytes are available or the wrapped stream has
+    nothing more to return.
+
+    :param wrapped: File-like object
+    """
+
+    def read(self, b=-1):
+        """Keep reading from source stream until either the source stream is done
+        or the requested number of bytes have been obtained.
+
+        :param int b: number of bytes to read
+        :return: All bytes read from wrapped stream
+        :rtype: bytes
+        """
+        remaining_bytes = b
+        data = io.BytesIO()
+        while True:
+            chunk = to_bytes(self.__wrapped__.read(remaining_bytes))
+
+            if not chunk:
+                break
+
+            data.write(chunk)
+            remaining_bytes -= len(chunk)
+
+            if remaining_bytes <= 0:
+                break
+        return data.getvalue()

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -866,9 +866,7 @@ class StreamDecryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
 
         buffer_length = len(self.output_buffer)
         if 0 <= b <= buffer_length:
-            _LOGGER.debug(
-                "%s bytes requested less than or equal to current output buffer size %s", b, len(self.output_buffer)
-            )
+            _LOGGER.debug("%d bytes requested less than or equal to current output buffer size %d", b, buffer_length)
             return
 
         if self._header.content_type == ContentType.FRAMED_DATA:

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -202,16 +202,16 @@ class _EncryptionStream(io.IOBase):
         # Open streams are currently always readable.
         return not self.closed
 
-    def read(self, b=None):
+    def read(self, b=-1):
         """Returns either the requested number of bytes or the entire stream.
 
         :param int b: Number of bytes to read
         :returns: Processed (encrypted or decrypted) bytes from source stream
         :rtype: bytes
         """
-        # Any negative value for b is interpreted as a full read
-        if b is not None and b < 0:
-            b = None
+        # NoneType value for b is interpretted as a full read for legacy compatibility
+        if b is None:
+            b = -1
 
         _LOGGER.debug("Stream read called, requesting %s bytes", b)
         output = io.BytesIO()

--- a/test/functional/test_f_aws_encryption_sdk_client.py
+++ b/test/functional/test_f_aws_encryption_sdk_client.py
@@ -628,8 +628,7 @@ class SometimesIncompleteReaderIO(io.BytesIO):
         256,  # 256: framed with inexact final frame size match
     ),
 )
-def test_incomplete_read_stream_cycle(caplog, frame_length):
-    caplog.set_level(logging.DEBUG)
+def test_incomplete_read_stream_cycle(frame_length):
     chunk_size = 21  # Will never be an exact match for the frame size
     key_provider = fake_kms_key_provider()
 

--- a/test/functional/test_f_aws_encryption_sdk_client.py
+++ b/test/functional/test_f_aws_encryption_sdk_client.py
@@ -669,4 +669,4 @@ def test_incomplete_read_stream_cycle(caplog, frame_length):
                     "Unexpected error encrypting message: infinite loop detected."
                 )
 
-    assert ciphertext != decrypted == VALUES["plaintext_128"]
+    assert ciphertext != decrypted == plaintext

--- a/test/functional/test_f_aws_encryption_sdk_client.py
+++ b/test/functional/test_f_aws_encryption_sdk_client.py
@@ -598,3 +598,75 @@ def test_stream_decryptor_readable():
         assert handler.readable()
         handler.read()
     assert not handler.readable()
+
+
+def exact_length_plaintext(length):
+    plaintext = b""
+    while len(plaintext) < length:
+        plaintext += VALUES["plaintext_128"]
+    return plaintext[:length]
+
+
+class SometimesIncompleteReaderIO(io.BytesIO):
+    def __init__(self, *args, **kwargs):
+        self.__read_counter = 0
+        super(SometimesIncompleteReaderIO, self).__init__(*args, **kwargs)
+
+    def read(self, size=-1):
+        """Every other read request, return fewer than the requested number of bytes if more than one byte requested."""
+        self.__read_counter += 1
+        if size > 1 and self.__read_counter % 2 == 0:
+            size //= 2
+        return super(SometimesIncompleteReaderIO, self).read(size)
+
+
+@pytest.mark.parametrize(
+    "frame_length",
+    (
+        0,  # 0: unframed
+        128,  # 128: framed with exact final frame size match
+        256,  # 256: framed with inexact final frame size match
+    ),
+)
+def test_incomplete_read_stream_cycle(caplog, frame_length):
+    caplog.set_level(logging.DEBUG)
+    chunk_size = 21  # Will never be an exact match for the frame size
+    key_provider = fake_kms_key_provider()
+
+    plaintext = exact_length_plaintext(384)
+    ciphertext = b""
+    cycle_count = 0
+    with aws_encryption_sdk.stream(
+        mode="encrypt",
+        source=SometimesIncompleteReaderIO(plaintext),
+        key_provider=key_provider,
+        frame_length=frame_length,
+    ) as encryptor:
+        while True:
+            cycle_count += 1
+            chunk = encryptor.read(chunk_size)
+            if not chunk:
+                break
+            ciphertext += chunk
+            if cycle_count > len(VALUES["plaintext_128"]):
+                raise aws_encryption_sdk.exceptions.AWSEncryptionSDKClientError(
+                    "Unexpected error encrypting message: infinite loop detected."
+                )
+
+    decrypted = b""
+    cycle_count = 0
+    with aws_encryption_sdk.stream(
+        mode="decrypt", source=SometimesIncompleteReaderIO(ciphertext), key_provider=key_provider
+    ) as decryptor:
+        while True:
+            cycle_count += 1
+            chunk = decryptor.read(chunk_size)
+            if not chunk:
+                break
+            decrypted += chunk
+            if cycle_count > len(VALUES["plaintext_128"]):
+                raise aws_encryption_sdk.exceptions.AWSEncryptionSDKClientError(
+                    "Unexpected error encrypting message: infinite loop detected."
+                )
+
+    assert ciphertext != decrypted == VALUES["plaintext_128"]

--- a/test/unit/test_streaming_client_encryption_stream.py
+++ b/test/unit/test_streaming_client_encryption_stream.py
@@ -20,6 +20,7 @@ from mock import MagicMock, PropertyMock, call, patch, sentinel
 
 import aws_encryption_sdk.exceptions
 from aws_encryption_sdk.internal.defaults import LINE_LENGTH
+from aws_encryption_sdk.internal.utils.streams import InsistentReaderBytesIO
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider
 from aws_encryption_sdk.streaming_client import _ClientConfig, _EncryptionStream
 
@@ -107,17 +108,19 @@ class TestEncryptionStream(object):
             line_length=io.DEFAULT_BUFFER_SIZE,
             source_length=mock_int_sentinel,
         )
-        assert mock_stream.config == MockClientConfig(
-            source=self.mock_source_stream,
-            key_provider=self.mock_key_provider,
-            mock_read_bytes=sentinel.read_bytes,
-            line_length=io.DEFAULT_BUFFER_SIZE,
-            source_length=mock_int_sentinel,
-        )
+
+        assert mock_stream.config.source == self.mock_source_stream
+        assert isinstance(mock_stream.config.source, InsistentReaderBytesIO)
+        assert mock_stream.config.key_provider is self.mock_key_provider
+        assert mock_stream.config.mock_read_bytes is sentinel.read_bytes
+        assert mock_stream.config.line_length == io.DEFAULT_BUFFER_SIZE
+        assert mock_stream.config.source_length is mock_int_sentinel
+
         assert mock_stream.bytes_read == 0
         assert mock_stream.output_buffer == b""
         assert not mock_stream._message_prepped
-        assert mock_stream.source_stream is self.mock_source_stream
+        assert mock_stream.source_stream == self.mock_source_stream
+        assert isinstance(mock_stream.source_stream, InsistentReaderBytesIO)
         assert mock_stream._stream_length is mock_int_sentinel
         assert mock_stream.line_length == io.DEFAULT_BUFFER_SIZE
 

--- a/test/unit/test_streaming_client_stream_decryptor.py
+++ b/test/unit/test_streaming_client_stream_decryptor.py
@@ -261,7 +261,7 @@ class TestStreamDecryptor(unittest.TestCase):
         test_decryptor._prep_non_framed()
 
         self.mock_deserialize_non_framed_values.assert_called_once_with(
-            stream=self.mock_input_stream, header=self.mock_header, verifier=sentinel.verifier
+            stream=test_decryptor.source_stream, header=self.mock_header, verifier=sentinel.verifier
         )
         assert test_decryptor.body_length == len(VALUES["data_128"])
         self.mock_get_aad_content_string.assert_called_once_with(

--- a/test/unit/test_util_streams.py
+++ b/test/unit/test_util_streams.py
@@ -16,13 +16,25 @@ import io
 import pytest
 
 from aws_encryption_sdk.exceptions import ActionNotAllowedError
+from aws_encryption_sdk.internal.str_ops import to_bytes, to_str
 from aws_encryption_sdk.internal.utils.streams import ROStream, TeeStream
+
+from .unit_test_utils import NothingButRead, SometimesIncompleteReaderIO
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-def data():
-    return io.BytesIO(b"asdijfhoaisjdfoiasjdfoijawef")
+def data(length=None, stream_type=io.BytesIO, converter=to_bytes):
+    source = b"asdijfhoaisjdfoiasjdfoijawef"
+    chunk_length = 100
+
+    if length is None:
+        length = len(source)
+
+    while len(source) < length:
+        source += source[:chunk_length]
+
+    return stream_type(converter(source[:length]))
 
 
 def test_rostream():
@@ -41,3 +53,24 @@ def test_teestream_full():
     raw_read = test_tee.read()
 
     assert data().getvalue() == raw_read == new_tee.getvalue()
+
+
+@pytest.mark.parametrize(
+    "stream_type, converter",
+    (
+        (io.BytesIO, to_bytes),
+        (SometimesIncompleteReaderIO, to_bytes),
+        (io.StringIO, to_str),
+        (NothingButRead, to_bytes),
+    ),
+)
+@pytest.mark.parametrize("bytes_to_read", (1, 4, 7, 99, 500))
+@pytest.mark.parametrize("source_length", (1, 11, 100))
+def test_insistent_stream(source_length, bytes_to_read, stream_type, converter):
+    source = data(length=source_length, stream_type=stream_type, converter=converter)
+
+    test = source.read(bytes_to_read)
+
+    assert (source_length >= bytes_to_read and len(test) == bytes_to_read) or (
+        source_length < bytes_to_read and len(test) == source_length
+    )

--- a/test/unit/test_util_streams.py
+++ b/test/unit/test_util_streams.py
@@ -17,7 +17,7 @@ import pytest
 
 from aws_encryption_sdk.exceptions import ActionNotAllowedError
 from aws_encryption_sdk.internal.str_ops import to_bytes, to_str
-from aws_encryption_sdk.internal.utils.streams import ROStream, TeeStream
+from aws_encryption_sdk.internal.utils.streams import InsistentReaderBytesIO, ROStream, TeeStream
 
 from .unit_test_utils import NothingButRead, SometimesIncompleteReaderIO
 
@@ -67,7 +67,7 @@ def test_teestream_full():
 @pytest.mark.parametrize("bytes_to_read", range(1, 102))
 @pytest.mark.parametrize("source_length", (1, 11, 100))
 def test_insistent_stream(source_length, bytes_to_read, stream_type, converter):
-    source = data(length=source_length, stream_type=stream_type, converter=converter)
+    source = InsistentReaderBytesIO(data(length=source_length, stream_type=stream_type, converter=converter))
 
     test = source.read(bytes_to_read)
 

--- a/test/unit/test_util_streams.py
+++ b/test/unit/test_util_streams.py
@@ -64,7 +64,7 @@ def test_teestream_full():
         (NothingButRead, to_bytes),
     ),
 )
-@pytest.mark.parametrize("bytes_to_read", (1, 4, 7, 99, 500))
+@pytest.mark.parametrize("bytes_to_read", range(1, 102))
 @pytest.mark.parametrize("source_length", (1, 11, 100))
 def test_insistent_stream(source_length, bytes_to_read, stream_type, converter):
     source = data(length=source_length, stream_type=stream_type, converter=converter)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -23,6 +23,7 @@ import aws_encryption_sdk.identifiers
 import aws_encryption_sdk.internal.utils
 from aws_encryption_sdk.exceptions import InvalidDataKeyError, SerializationError, UnknownIdentityError
 from aws_encryption_sdk.internal.defaults import MAX_FRAME_SIZE, MESSAGE_ID_LENGTH
+from aws_encryption_sdk.internal.utils.streams import InsistentReaderBytesIO
 from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, MasterKeyInfo, RawDataKey
 
 from .test_values import VALUES
@@ -31,16 +32,19 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 def test_prep_stream_data_passthrough():
-    test = aws_encryption_sdk.internal.utils.prep_stream_data(sentinel.not_a_string_or_bytes)
+    test = aws_encryption_sdk.internal.utils.prep_stream_data(io.BytesIO(b"some data"))
 
-    assert test is sentinel.not_a_string_or_bytes
+    assert isinstance(test, InsistentReaderBytesIO)
 
 
 @pytest.mark.parametrize("source", (u"some unicode data ловие", b"\x00\x01\x02"))
 def test_prep_stream_data_wrap(source):
     test = aws_encryption_sdk.internal.utils.prep_stream_data(source)
 
+    # Check the wrapped stream
     assert isinstance(test, io.BytesIO)
+    # Check the wrapping stream
+    assert isinstance(test, InsistentReaderBytesIO)
 
 
 class TestUtils(unittest.TestCase):

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 """Utility functions to handle common test framework functions."""
 import copy
+import io
 import itertools
 
 
@@ -50,3 +51,24 @@ def build_valid_kwargs_list(base, optional_kwargs):
             _kwargs.update(dict(valid_options))
             valid_kwargs.append(_kwargs)
     return valid_kwargs
+
+
+class SometimesIncompleteReaderIO(io.BytesIO):
+    def __init__(self, *args, **kwargs):
+        self.__read_counter = 0
+        super(SometimesIncompleteReaderIO, self).__init__(*args, **kwargs)
+
+    def read(self, size=-1):
+        """Every other read request, return fewer than the requested number of bytes if more than one byte requested."""
+        self.__read_counter += 1
+        if size > 1 and self.__read_counter % 2 == 0:
+            size //= 2
+        return super(SometimesIncompleteReaderIO, self).read(size)
+
+
+class NothingButRead(object):
+    def __init__(self, data):
+        self._data = io.BytesIO(data)
+
+    def read(self, size=-1):
+        return self._data.read(size)

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -55,13 +55,13 @@ def build_valid_kwargs_list(base, optional_kwargs):
 
 class SometimesIncompleteReaderIO(io.BytesIO):
     def __init__(self, *args, **kwargs):
-        self.__read_counter = 0
+        self._read_counter = 0
         super(SometimesIncompleteReaderIO, self).__init__(*args, **kwargs)
 
     def read(self, size=-1):
         """Every other read request, return fewer than the requested number of bytes if more than one byte requested."""
-        self.__read_counter += 1
-        if size > 1 and self.__read_counter % 2 == 0:
+        self._read_counter += 1
+        if size > 1 and self._read_counter % 2 == 0:
             size //= 2
         return super(SometimesIncompleteReaderIO, self).read(size)
 
@@ -72,3 +72,10 @@ class NothingButRead(object):
 
     def read(self, size=-1):
         return self._data.read(size)
+
+
+class ExactlyTwoReads(SometimesIncompleteReaderIO):
+    def read(self, size=-1):
+        if self._read_counter >= 2:
+            self.close()
+        return super(ExactlyTwoReads, self).read(size)


### PR DESCRIPTION
*Issue #, if available:* #24 

*Description of changes:*
As noted in #24, the `streaming_client` classes have not historically correctly handled partial reads. Rather than accepting reads from the source stream that return fewer than the requested number of bytes, they assumed that this meant the source stream was complete. Per PEP 3116, this is incorrect: the stream should not be considered complete until no bytes are returned.

In order to simplify logic everywhere else, I ended up just adding a `ProxyObject` wrapper that keeps hitting the wrapped stream on read until it either gets the requested number of bytes or hits the end of the wrapped stream (as indicated by the stream returning nothing).

Tightly coupled with this was updating the fix made in #98 to correctly normalize to the bytes to read to `-1` rather than `None`. This required a few small tweaks throughout `streaming_client` to correctly handle this new value.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
