### PR TITLE
Remove requirement for tell() on decrypt

### DIFF
--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -767,7 +767,7 @@ class StreamDecryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
 
     def _prep_non_framed(self):
         """Prepare the opening data for a non-framed message."""
-        self._unframed_body_iv, self.body_length = aws_encryption_sdk.internal.formatting.deserialize.deserialize_non_framed_values(
+        self._unframed_body_iv, self.body_length = aws_encryption_sdk.internal.formatting.deserialize.deserialize_non_framed_values(  # noqa # pylint: disable=line-too-long
             stream=self.source_stream, header=self._header, verifier=self.verifier
         )
 

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -755,11 +755,13 @@ class StreamDecryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
 
     @property
     def body_start(self):
+        """Log deprecation warning when body_start is accessed."""
         _LOGGER.warning("StreamDecryptor.body_start is deprecated and will be removed in 1.4.0")
         return self._body_start
 
     @property
     def body_end(self):
+        """Log deprecation warning when body_end is accessed."""
         _LOGGER.warning("StreamDecryptor.body_end is deprecated and will be removed in 1.4.0")
         return self._body_end
 

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -804,9 +804,7 @@ class StreamDecryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
             self.verifier.update(ciphertext)
 
         tag = aws_encryption_sdk.internal.formatting.deserialize.deserialize_tag(
-            stream=self.source_stream,
-            header=self._header,
-            verifier=self.verifier,
+            stream=self.source_stream, header=self._header, verifier=self.verifier
         )
 
         aad_content_string = aws_encryption_sdk.internal.utils.get_aad_content_string(

--- a/test/functional/test_f_aws_encryption_sdk_client.py
+++ b/test/functional/test_f_aws_encryption_sdk_client.py
@@ -761,7 +761,9 @@ def test_cycle_nothing_but_read(frame_length):
     raw_plaintext = exact_length_plaintext(100)
     plaintext = NothingButRead(raw_plaintext)
     key_provider = fake_kms_key_provider()
-    raw_ciphertext, _encrypt_header = aws_encryption_sdk.encrypt(source=plaintext, key_provider=key_provider, frame_length=frame_length)
+    raw_ciphertext, _encrypt_header = aws_encryption_sdk.encrypt(
+        source=plaintext, key_provider=key_provider, frame_length=frame_length
+    )
     ciphertext = NothingButRead(raw_ciphertext)
     decrypted, _decrypt_header = aws_encryption_sdk.decrypt(source=ciphertext, key_provider=key_provider)
     assert raw_plaintext == decrypted
@@ -773,7 +775,9 @@ def test_encrypt_nothing_but_read(frame_length):
     raw_plaintext = exact_length_plaintext(100)
     plaintext = NothingButRead(raw_plaintext)
     key_provider = fake_kms_key_provider()
-    ciphertext, _encrypt_header = aws_encryption_sdk.encrypt(source=plaintext, key_provider=key_provider, frame_length=frame_length)
+    ciphertext, _encrypt_header = aws_encryption_sdk.encrypt(
+        source=plaintext, key_provider=key_provider, frame_length=frame_length
+    )
     decrypted, _decrypt_header = aws_encryption_sdk.decrypt(source=ciphertext, key_provider=key_provider)
     assert raw_plaintext == decrypted
 
@@ -783,7 +787,9 @@ def test_encrypt_nothing_but_read(frame_length):
 def test_decrypt_nothing_but_read(frame_length):
     plaintext = exact_length_plaintext(100)
     key_provider = fake_kms_key_provider()
-    raw_ciphertext, _encrypt_header = aws_encryption_sdk.encrypt(source=plaintext, key_provider=key_provider, frame_length=frame_length)
+    raw_ciphertext, _encrypt_header = aws_encryption_sdk.encrypt(
+        source=plaintext, key_provider=key_provider, frame_length=frame_length
+    )
     ciphertext = NothingButRead(raw_ciphertext)
     decrypted, _decrypt_header = aws_encryption_sdk.decrypt(source=ciphertext, key_provider=key_provider)
     assert plaintext == decrypted
@@ -801,8 +807,7 @@ def test_decryptor_deprecated_attributes(caplog, attribute, no_later_than):
     assert decrypted == plaintext
     assert hasattr(decryptor, attribute)
     watch_string = "StreamDecryptor.{name} is deprecated and will be removed in {version}".format(
-        name=attribute,
-        version=no_later_than
+        name=attribute, version=no_later_than
     )
     assert watch_string in caplog.text
     assert aws_encryption_sdk.__version__ < no_later_than

--- a/test/unit/test_deserialize.py
+++ b/test/unit/test_deserialize.py
@@ -31,14 +31,13 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 def test_deserialize_non_framed_values():
-    iv = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11'
+    iv = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11"
     length = 42
     packed = struct.pack(">12sQ", iv, length)
     mock_header = MagicMock(algorithm=MagicMock(iv_len=12))
 
     parsed_iv, parsed_length = aws_encryption_sdk.internal.formatting.deserialize.deserialize_non_framed_values(
-        stream=io.BytesIO(packed),
-        header=mock_header
+        stream=io.BytesIO(packed), header=mock_header
     )
 
     assert parsed_iv == iv
@@ -46,13 +45,12 @@ def test_deserialize_non_framed_values():
 
 
 def test_deserialize_tag():
-    tag = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15'
+    tag = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15"
     packed = struct.pack(">16s", tag)
     mock_header = MagicMock(algorithm=MagicMock(auth_len=16))
 
     parsed_tag = aws_encryption_sdk.internal.formatting.deserialize.deserialize_tag(
-        stream=io.BytesIO(packed),
-        header=mock_header
+        stream=io.BytesIO(packed), header=mock_header
     )
 
     assert parsed_tag == tag

--- a/test/unit/test_streaming_client_encryption_stream.py
+++ b/test/unit/test_streaming_client_encryption_stream.py
@@ -20,11 +20,11 @@ from mock import MagicMock, PropertyMock, call, patch, sentinel
 
 import aws_encryption_sdk.exceptions
 from aws_encryption_sdk.internal.defaults import LINE_LENGTH
-from aws_encryption_sdk.internal.utils.streams import InsistentReaderBytesIO
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider
 from aws_encryption_sdk.streaming_client import _ClientConfig, _EncryptionStream
 
 from .test_values import VALUES
+from .unit_test_utils import assert_prepped_stream_identity
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
@@ -110,7 +110,7 @@ class TestEncryptionStream(object):
         )
 
         assert mock_stream.config.source == self.mock_source_stream
-        assert isinstance(mock_stream.config.source, InsistentReaderBytesIO)
+        assert_prepped_stream_identity(mock_stream.config.source, object)
         assert mock_stream.config.key_provider is self.mock_key_provider
         assert mock_stream.config.mock_read_bytes is sentinel.read_bytes
         assert mock_stream.config.line_length == io.DEFAULT_BUFFER_SIZE
@@ -120,7 +120,7 @@ class TestEncryptionStream(object):
         assert mock_stream.output_buffer == b""
         assert not mock_stream._message_prepped
         assert mock_stream.source_stream == self.mock_source_stream
-        assert isinstance(mock_stream.source_stream, InsistentReaderBytesIO)
+        assert_prepped_stream_identity(mock_stream.source_stream, object)
         assert mock_stream._stream_length is mock_int_sentinel
         assert mock_stream.line_length == io.DEFAULT_BUFFER_SIZE
 

--- a/test/unit/test_streaming_client_stream_decryptor.py
+++ b/test/unit/test_streaming_client_stream_decryptor.py
@@ -41,7 +41,7 @@ class TestStreamDecryptor(unittest.TestCase):
         self.mock_header.encrypted_data_keys = sentinel.encrypted_data_keys
         self.mock_header.encryption_context = sentinel.encryption_context
 
-        self.mock_raw_header = b'some bytes'
+        self.mock_raw_header = b"some bytes"
 
         self.mock_input_stream = MagicMock()
         self.mock_input_stream.__class__ = io.IOBase
@@ -74,8 +74,7 @@ class TestStreamDecryptor(unittest.TestCase):
         self.mock_deserialize_non_framed_values.return_value = (sentinel.iv, len(VALUES["data_128"]))
         # Set up deserialize_tag_value patch
         self.mock_deserialize_tag_patcher = patch(
-            "aws_encryption_sdk.streaming_client"
-            ".aws_encryption_sdk.internal.formatting.deserialize.deserialize_tag"
+            "aws_encryption_sdk.streaming_client" ".aws_encryption_sdk.internal.formatting.deserialize.deserialize_tag"
         )
         self.mock_deserialize_tag = self.mock_deserialize_tag_patcher.start()
         self.mock_deserialize_tag.return_value = sentinel.tag
@@ -221,9 +220,7 @@ class TestStreamDecryptor(unittest.TestCase):
     @patch("aws_encryption_sdk.streaming_client.Verifier")
     @patch("aws_encryption_sdk.streaming_client.DecryptionMaterialsRequest")
     @patch("aws_encryption_sdk.streaming_client.derive_data_encryption_key")
-    def test_read_header_no_verifier(
-        self, mock_derive_datakey, mock_decrypt_materials_request, mock_verifier
-    ):
+    def test_read_header_no_verifier(self, mock_derive_datakey, mock_decrypt_materials_request, mock_verifier):
         self.mock_materials_manager.decrypt_materials.return_value = MagicMock(
             data_key=VALUES["data_key_obj"], verification_key=None
         )
@@ -286,9 +283,7 @@ class TestStreamDecryptor(unittest.TestCase):
         test = test_decryptor._read_bytes_from_non_framed_body(5)
 
         self.mock_deserialize_tag.assert_called_once_with(
-            stream=test_decryptor.source_stream,
-            header=test_decryptor._header,
-            verifier=test_decryptor.verifier
+            stream=test_decryptor.source_stream, header=test_decryptor._header, verifier=test_decryptor.verifier
         )
         self.mock_get_aad_content_string.assert_called_once_with(
             content_type=self.mock_header.content_type, is_final_frame=True

--- a/test/unit/test_streaming_client_stream_decryptor.py
+++ b/test/unit/test_streaming_client_stream_decryptor.py
@@ -37,9 +37,11 @@ class TestStreamDecryptor(unittest.TestCase):
             data_key=VALUES["data_key_obj"], verification_key=sentinel.verification_key
         )
         self.mock_header = MagicMock()
-        self.mock_header.algorithm = MagicMock(__class__=Algorithm)
+        self.mock_header.algorithm = MagicMock(__class__=Algorithm, iv_len=12)
         self.mock_header.encrypted_data_keys = sentinel.encrypted_data_keys
         self.mock_header.encryption_context = sentinel.encryption_context
+
+        self.mock_raw_header = b'some bytes'
 
         self.mock_input_stream = MagicMock()
         self.mock_input_stream.__class__ = io.IOBase
@@ -50,7 +52,7 @@ class TestStreamDecryptor(unittest.TestCase):
             "aws_encryption_sdk.streaming_client.aws_encryption_sdk.internal.formatting.deserialize.deserialize_header"
         )
         self.mock_deserialize_header = self.mock_deserialize_header_patcher.start()
-        self.mock_deserialize_header.return_value = self.mock_header, sentinel.raw_header
+        self.mock_deserialize_header.return_value = self.mock_header, self.mock_raw_header
         # Set up deserialize_header_auth patch
         self.mock_deserialize_header_auth_patcher = patch(
             "aws_encryption_sdk.streaming_client"
@@ -69,7 +71,14 @@ class TestStreamDecryptor(unittest.TestCase):
             ".aws_encryption_sdk.internal.formatting.deserialize.deserialize_non_framed_values"
         )
         self.mock_deserialize_non_framed_values = self.mock_deserialize_non_framed_values_patcher.start()
-        self.mock_deserialize_non_framed_values.return_value = (sentinel.iv, sentinel.tag, len(VALUES["data_128"]))
+        self.mock_deserialize_non_framed_values.return_value = (sentinel.iv, len(VALUES["data_128"]))
+        # Set up deserialize_tag_value patch
+        self.mock_deserialize_tag_patcher = patch(
+            "aws_encryption_sdk.streaming_client"
+            ".aws_encryption_sdk.internal.formatting.deserialize.deserialize_tag"
+        )
+        self.mock_deserialize_tag = self.mock_deserialize_tag_patcher.start()
+        self.mock_deserialize_tag.return_value = sentinel.tag
         # Set up get_aad_content_string patch
         self.mock_get_aad_content_string_patcher = patch(
             "aws_encryption_sdk.streaming_client.aws_encryption_sdk.internal.utils.get_aad_content_string"
@@ -113,6 +122,7 @@ class TestStreamDecryptor(unittest.TestCase):
         self.mock_deserialize_header_auth_patcher.stop()
         self.mock_validate_header_patcher.stop()
         self.mock_deserialize_non_framed_values_patcher.stop()
+        self.mock_deserialize_tag_patcher.stop()
         self.mock_get_aad_content_string_patcher.stop()
         self.mock_assemble_content_aad_patcher.stop()
         self.mock_decryptor_patcher.stop()
@@ -151,11 +161,9 @@ class TestStreamDecryptor(unittest.TestCase):
     @patch("aws_encryption_sdk.streaming_client.Verifier")
     @patch("aws_encryption_sdk.streaming_client.DecryptionMaterialsRequest")
     @patch("aws_encryption_sdk.streaming_client.derive_data_encryption_key")
-    @patch("aws_encryption_sdk.streaming_client.StreamDecryptor.__init__")
-    def test_read_header(self, mock_init, mock_derive_datakey, mock_decrypt_materials_request, mock_verifier):
+    def test_read_header(self, mock_derive_datakey, mock_decrypt_materials_request, mock_verifier):
         mock_verifier_instance = MagicMock()
         mock_verifier.from_key_bytes.return_value = mock_verifier_instance
-        mock_init.return_value = None
         ct_stream = io.BytesIO(VALUES["data_128"])
         test_decryptor = StreamDecryptor(materials_manager=self.mock_materials_manager, source=ct_stream)
         test_decryptor.source_stream = ct_stream
@@ -175,7 +183,7 @@ class TestStreamDecryptor(unittest.TestCase):
         self.mock_materials_manager.decrypt_materials.assert_called_once_with(
             request=mock_decrypt_materials_request.return_value
         )
-        mock_verifier_instance.update.assert_called_once_with(sentinel.raw_header)
+        mock_verifier_instance.update.assert_called_once_with(self.mock_raw_header)
         self.mock_deserialize_header_auth.assert_called_once_with(
             stream=ct_stream, algorithm=self.mock_header.algorithm, verifier=mock_verifier_instance
         )
@@ -188,18 +196,16 @@ class TestStreamDecryptor(unittest.TestCase):
         self.mock_validate_header.assert_called_once_with(
             header=self.mock_header,
             header_auth=sentinel.header_auth,
-            raw_header=sentinel.raw_header,
+            raw_header=self.mock_raw_header,
             data_key=mock_derive_datakey.return_value,
         )
         assert test_header is self.mock_header
         assert test_header_auth is sentinel.header_auth
 
     @patch("aws_encryption_sdk.streaming_client.derive_data_encryption_key")
-    @patch("aws_encryption_sdk.streaming_client.StreamDecryptor.__init__")
-    def test_read_header_frame_too_large(self, mock_init, mock_derive_datakey):
+    def test_read_header_frame_too_large(self, mock_derive_datakey):
         self.mock_header.content_type = ContentType.FRAMED_DATA
         self.mock_header.frame_length = 1024
-        mock_init.return_value = None
         ct_stream = io.BytesIO(VALUES["data_128"])
         test_decryptor = StreamDecryptor(key_provider=self.mock_key_provider, source=ct_stream, max_body_length=10)
         test_decryptor.key_provider = self.mock_key_provider
@@ -215,14 +221,12 @@ class TestStreamDecryptor(unittest.TestCase):
     @patch("aws_encryption_sdk.streaming_client.Verifier")
     @patch("aws_encryption_sdk.streaming_client.DecryptionMaterialsRequest")
     @patch("aws_encryption_sdk.streaming_client.derive_data_encryption_key")
-    @patch("aws_encryption_sdk.streaming_client.StreamDecryptor.__init__")
     def test_read_header_no_verifier(
-        self, mock_init, mock_derive_datakey, mock_decrypt_materials_request, mock_verifier
+        self, mock_derive_datakey, mock_decrypt_materials_request, mock_verifier
     ):
         self.mock_materials_manager.decrypt_materials.return_value = MagicMock(
             data_key=VALUES["data_key_obj"], verification_key=None
         )
-        mock_init.return_value = None
         test_decryptor = StreamDecryptor(materials_manager=self.mock_materials_manager, source=self.mock_input_stream)
         test_decryptor.key_provider = self.mock_key_provider
         test_decryptor.source_stream = self.mock_input_stream
@@ -264,6 +268,28 @@ class TestStreamDecryptor(unittest.TestCase):
             stream=test_decryptor.source_stream, header=self.mock_header, verifier=sentinel.verifier
         )
         assert test_decryptor.body_length == len(VALUES["data_128"])
+        assert test_decryptor.body_start == self.mock_header.algorithm.iv_len + 8
+        assert test_decryptor.body_end == self.mock_header.algorithm.iv_len + 8 + len(VALUES["data_128"])
+
+    def test_read_bytes_from_non_framed(self):
+        ct_stream = io.BytesIO(VALUES["data_128"])
+        test_decryptor = StreamDecryptor(key_provider=self.mock_key_provider, source=ct_stream)
+        test_decryptor.body_length = len(VALUES["data_128"])
+        test_decryptor.decryptor = self.mock_decryptor_instance
+        test_decryptor._header = self.mock_header
+        test_decryptor.verifier = MagicMock()
+        test_decryptor._derived_data_key = sentinel.derived_data_key
+        test_decryptor._unframed_body_iv = sentinel.unframed_body_iv
+        self.mock_decryptor_instance.update.return_value = b"1234"
+        self.mock_decryptor_instance.finalize.return_value = b"5678"
+
+        test = test_decryptor._read_bytes_from_non_framed_body(5)
+
+        self.mock_deserialize_tag.assert_called_once_with(
+            stream=test_decryptor.source_stream,
+            header=test_decryptor._header,
+            verifier=test_decryptor.verifier
+        )
         self.mock_get_aad_content_string.assert_called_once_with(
             content_type=self.mock_header.content_type, is_final_frame=True
         )
@@ -277,24 +303,10 @@ class TestStreamDecryptor(unittest.TestCase):
             algorithm=self.mock_header.algorithm,
             key=sentinel.derived_data_key,
             associated_data=sentinel.associated_data,
-            iv=sentinel.iv,
+            iv=sentinel.unframed_body_iv,
             tag=sentinel.tag,
         )
         assert test_decryptor.decryptor is self.mock_decryptor_instance
-        assert test_decryptor.body_start == 0
-        assert test_decryptor.body_end == len(VALUES["data_128"])
-
-    def test_read_bytes_from_non_framed(self):
-        ct_stream = io.BytesIO(VALUES["data_128"])
-        test_decryptor = StreamDecryptor(key_provider=self.mock_key_provider, source=ct_stream)
-        test_decryptor.body_start = 0
-        test_decryptor.body_length = test_decryptor.body_end = len(VALUES["data_128"])
-        test_decryptor.decryptor = self.mock_decryptor_instance
-        test_decryptor._header = self.mock_header
-        test_decryptor.verifier = MagicMock()
-        self.mock_decryptor_instance.update.return_value = b"1234"
-        self.mock_decryptor_instance.finalize.return_value = b"5678"
-        test = test_decryptor._read_bytes_from_non_framed_body(5)
         test_decryptor.verifier.update.assert_called_once_with(VALUES["data_128"])
         self.mock_decryptor_instance.update.assert_called_once_with(VALUES["data_128"])
         assert test_decryptor.source_stream.closed
@@ -303,8 +315,7 @@ class TestStreamDecryptor(unittest.TestCase):
     def test_read_bytes_from_non_framed_message_body_too_small(self):
         ct_stream = io.BytesIO(VALUES["data_128"])
         test_decryptor = StreamDecryptor(key_provider=self.mock_key_provider, source=ct_stream)
-        test_decryptor.body_start = 0
-        test_decryptor.body_length = test_decryptor.body_end = len(VALUES["data_128"] * 2)
+        test_decryptor.body_length = len(VALUES["data_128"] * 2)
         test_decryptor._header = self.mock_header
         with six.assertRaisesRegex(
             self, SerializationError, "Total message body contents less than specified in body description"
@@ -314,10 +325,11 @@ class TestStreamDecryptor(unittest.TestCase):
     def test_read_bytes_from_non_framed_no_verifier(self):
         ct_stream = io.BytesIO(VALUES["data_128"])
         test_decryptor = StreamDecryptor(key_provider=self.mock_key_provider, source=ct_stream)
-        test_decryptor.body_start = 0
-        test_decryptor.body_length = test_decryptor.body_end = len(VALUES["data_128"])
+        test_decryptor.body_length = len(VALUES["data_128"])
         test_decryptor.decryptor = self.mock_decryptor_instance
         test_decryptor._header = self.mock_header
+        test_decryptor._derived_data_key = sentinel.derived_data_key
+        test_decryptor._unframed_body_iv = sentinel.unframed_body_iv
         test_decryptor.verifier = None
         self.mock_decryptor_instance.update.return_value = b"1234"
         test_decryptor._read_bytes_from_non_framed_body(5)
@@ -325,19 +337,19 @@ class TestStreamDecryptor(unittest.TestCase):
     def test_read_bytes_from_non_framed_finalize(self):
         ct_stream = io.BytesIO(VALUES["data_128"])
         test_decryptor = StreamDecryptor(key_provider=self.mock_key_provider, source=ct_stream)
-        test_decryptor.body_start = 0
-        test_decryptor.body_length = test_decryptor.body_end = len(VALUES["data_128"])
+        test_decryptor.body_length = len(VALUES["data_128"])
         test_decryptor.decryptor = self.mock_decryptor_instance
         test_decryptor.verifier = MagicMock()
         test_decryptor._header = self.mock_header
+        test_decryptor._derived_data_key = sentinel.derived_data_key
+        test_decryptor._unframed_body_iv = sentinel.unframed_body_iv
         self.mock_decryptor_instance.update.return_value = b"1234"
         self.mock_decryptor_instance.finalize.return_value = b"5678"
+
         test = test_decryptor._read_bytes_from_non_framed_body(len(VALUES["data_128"]) + 1)
+
         test_decryptor.verifier.update.assert_called_once_with(VALUES["data_128"])
         self.mock_decryptor_instance.update.assert_called_once_with(VALUES["data_128"])
-        self.mock_update_verifier_with_tag.assert_called_once_with(
-            stream=test_decryptor.source_stream, header=test_decryptor._header, verifier=test_decryptor.verifier
-        )
         self.mock_deserialize_footer.assert_called_once_with(
             stream=test_decryptor.source_stream, verifier=test_decryptor.verifier
         )

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -23,10 +23,10 @@ import aws_encryption_sdk.identifiers
 import aws_encryption_sdk.internal.utils
 from aws_encryption_sdk.exceptions import InvalidDataKeyError, SerializationError, UnknownIdentityError
 from aws_encryption_sdk.internal.defaults import MAX_FRAME_SIZE, MESSAGE_ID_LENGTH
-from aws_encryption_sdk.internal.utils.streams import InsistentReaderBytesIO
 from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, MasterKeyInfo, RawDataKey
 
 from .test_values import VALUES
+from .unit_test_utils import assert_prepped_stream_identity
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
@@ -34,17 +34,14 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 def test_prep_stream_data_passthrough():
     test = aws_encryption_sdk.internal.utils.prep_stream_data(io.BytesIO(b"some data"))
 
-    assert isinstance(test, InsistentReaderBytesIO)
+    assert_prepped_stream_identity(test, io.BytesIO)
 
 
 @pytest.mark.parametrize("source", (u"some unicode data ловие", b"\x00\x01\x02"))
 def test_prep_stream_data_wrap(source):
     test = aws_encryption_sdk.internal.utils.prep_stream_data(source)
 
-    # Check the wrapped stream
-    assert isinstance(test, io.BytesIO)
-    # Check the wrapping stream
-    assert isinstance(test, InsistentReaderBytesIO)
+    assert_prepped_stream_identity(test, io.BytesIO)
 
 
 class TestUtils(unittest.TestCase):

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -14,6 +14,7 @@
 import copy
 import io
 import itertools
+from aws_encryption_sdk.internal.utils.streams import FauxCloseStream, LinearTellStream, InsistentReaderBytesIO
 
 
 def all_valid_kwargs(valid_kwargs):
@@ -79,3 +80,15 @@ class ExactlyTwoReads(SometimesIncompleteReaderIO):
         if self._read_counter >= 2:
             self.close()
         return super(ExactlyTwoReads, self).read(size)
+
+
+class FailingTeller(object):
+    def tell(self):
+        raise IOError("Tell not allowed!")
+
+
+def assert_prepped_stream_identity(prepped_stream, wrapped_type):
+    # Check the wrapped stream
+    assert isinstance(prepped_stream, wrapped_type)
+    # Check the wrapping streams
+    assert isinstance(prepped_stream, InsistentReaderBytesIO)

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -14,7 +14,7 @@
 import copy
 import io
 import itertools
-from aws_encryption_sdk.internal.utils.streams import FauxCloseStream, LinearTellStream, InsistentReaderBytesIO
+from aws_encryption_sdk.internal.utils.streams import InsistentReaderBytesIO
 
 
 def all_valid_kwargs(valid_kwargs):

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -14,6 +14,7 @@
 import copy
 import io
 import itertools
+
 from aws_encryption_sdk.internal.utils.streams import InsistentReaderBytesIO
 
 


### PR DESCRIPTION
*Issue #, if available:* #103 

*Description of changes:*
This is the first in a series of changes to implement #103.

This removes the need for the source stream to implement `tell()` on the decrypt path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
