### PR TITLE
fix logging issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,14 @@
 Changelog
 *********
 
-1.3.8 -- 2018-xx-xx
+1.3.8 -- 2018-11-15
 ===================
+
+Bugfixes
+--------
+
+* Remove debug logging that may contain input data when encrypting non-default unframed messages.
+  `#105 <https://github.com/aws/aws-encryption-sdk-python/pull/105>`_
 
 Minor
 -----

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.primitives.kdf import hkdf
 
 from aws_encryption_sdk.exceptions import InvalidAlgorithmError
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 USER_AGENT_SUFFIX = "AwsEncryptionSdkPython/{}".format(__version__)
 
 


### PR DESCRIPTION
Remove debug logging that may contain input data when encrypting non-default unframed messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
