### PR TITLE
Remove requirement for tell() on source_stream

### DIFF
--- a/test/functional/test_f_aws_encryption_sdk_client.py
+++ b/test/functional/test_f_aws_encryption_sdk_client.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from mock import MagicMock
+from wrapt import ObjectProxy
 
 import aws_encryption_sdk
 from aws_encryption_sdk import KMSMasterKeyProvider
@@ -749,31 +750,57 @@ def test_plaintext_logs_stream(caplog, capsys, plaintext_length, frame_size):
 
 class NothingButRead(object):
     def __init__(self, data):
-        self._data = io.BytesIO(data)
+        self._data = data
 
     def read(self, size=-1):
         return self._data.read(size)
 
 
-@pytest.mark.xfail
+class NoTell(ObjectProxy):
+    def tell(self):
+        raise NotImplementedError("NoTell does not tell().")
+
+
+class NoClose(ObjectProxy):
+    closed = NotImplemented
+
+    def close(self):
+        raise NotImplementedError("NoClose does not close().")
+
+
+@pytest.mark.parametrize(
+    "wrapping_class",
+    (
+        pytest.param(NoTell, marks=pytest.mark.xfail),
+        pytest.param(NoClose, marks=pytest.mark.xfail(strict=True)),
+        pytest.param(NothingButRead, marks=pytest.mark.xfail(strict=True)),
+    ),
+)
 @pytest.mark.parametrize("frame_length", (0, 1024))
-def test_cycle_nothing_but_read(frame_length):
+def test_cycle_minimal_source_stream_api(frame_length, wrapping_class):
     raw_plaintext = exact_length_plaintext(100)
-    plaintext = NothingButRead(raw_plaintext)
+    plaintext = wrapping_class(io.BytesIO(raw_plaintext))
     key_provider = fake_kms_key_provider()
     raw_ciphertext, _encrypt_header = aws_encryption_sdk.encrypt(
         source=plaintext, key_provider=key_provider, frame_length=frame_length
     )
-    ciphertext = NothingButRead(raw_ciphertext)
+    ciphertext = wrapping_class(io.BytesIO(raw_ciphertext))
     decrypted, _decrypt_header = aws_encryption_sdk.decrypt(source=ciphertext, key_provider=key_provider)
     assert raw_plaintext == decrypted
 
 
-@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "wrapping_class",
+    (
+        pytest.param(NoTell, marks=pytest.mark.xfail),
+        pytest.param(NoClose, marks=pytest.mark.xfail(strict=True)),
+        pytest.param(NothingButRead, marks=pytest.mark.xfail(strict=True)),
+    ),
+)
 @pytest.mark.parametrize("frame_length", (0, 1024))
-def test_encrypt_nothing_but_read(frame_length):
+def test_encrypt_minimal_source_stream_api(frame_length, wrapping_class):
     raw_plaintext = exact_length_plaintext(100)
-    plaintext = NothingButRead(raw_plaintext)
+    plaintext = wrapping_class(io.BytesIO(raw_plaintext))
     key_provider = fake_kms_key_provider()
     ciphertext, _encrypt_header = aws_encryption_sdk.encrypt(
         source=plaintext, key_provider=key_provider, frame_length=frame_length
@@ -782,15 +809,22 @@ def test_encrypt_nothing_but_read(frame_length):
     assert raw_plaintext == decrypted
 
 
-@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "wrapping_class",
+    (
+        NoTell,
+        pytest.param(NoClose, marks=pytest.mark.xfail(strict=True)),
+        pytest.param(NothingButRead, marks=pytest.mark.xfail(strict=True)),
+    ),
+)
 @pytest.mark.parametrize("frame_length", (0, 1024))
-def test_decrypt_nothing_but_read(frame_length):
+def test_decrypt_minimal_source_stream_api(frame_length, wrapping_class):
     plaintext = exact_length_plaintext(100)
     key_provider = fake_kms_key_provider()
     raw_ciphertext, _encrypt_header = aws_encryption_sdk.encrypt(
         source=plaintext, key_provider=key_provider, frame_length=frame_length
     )
-    ciphertext = NothingButRead(raw_ciphertext)
+    ciphertext = wrapping_class(io.BytesIO(raw_ciphertext))
     decrypted, _decrypt_header = aws_encryption_sdk.decrypt(source=ciphertext, key_provider=key_provider)
     assert plaintext == decrypted
 

--- a/test/functional/test_f_aws_encryption_sdk_client.py
+++ b/test/functional/test_f_aws_encryption_sdk_client.py
@@ -771,7 +771,7 @@ class NoClose(ObjectProxy):
 @pytest.mark.parametrize(
     "wrapping_class",
     (
-        pytest.param(NoTell, marks=pytest.mark.xfail),
+        NoTell,
         pytest.param(NoClose, marks=pytest.mark.xfail(strict=True)),
         pytest.param(NothingButRead, marks=pytest.mark.xfail(strict=True)),
     ),
@@ -792,7 +792,7 @@ def test_cycle_minimal_source_stream_api(frame_length, wrapping_class):
 @pytest.mark.parametrize(
     "wrapping_class",
     (
-        pytest.param(NoTell, marks=pytest.mark.xfail),
+        NoTell,
         pytest.param(NoClose, marks=pytest.mark.xfail(strict=True)),
         pytest.param(NothingButRead, marks=pytest.mark.xfail(strict=True)),
     ),

--- a/test/unit/test_streaming_client_stream_encryptor.py
+++ b/test/unit/test_streaming_client_stream_encryptor.py
@@ -382,7 +382,10 @@ class TestStreamEncryptor(unittest.TestCase):
         test_encryptor.encryptor = MagicMock()
         test_encryptor._encryption_materials = self.mock_encryption_materials
         test_encryptor.encryptor.update.return_value = sentinel.ciphertext
+        test_encryptor._StreamEncryptor__unframed_plaintext_cache = pt_stream
+
         test = test_encryptor._read_bytes_to_non_framed_body(5)
+
         test_encryptor.encryptor.update.assert_called_once_with(self.plaintext[:5])
         test_encryptor.signer.update.assert_called_once_with(sentinel.ciphertext)
         assert not test_encryptor.source_stream.closed
@@ -392,6 +395,8 @@ class TestStreamEncryptor(unittest.TestCase):
         pt_stream = io.BytesIO(self.plaintext)
         test_encryptor = StreamEncryptor(source=pt_stream, key_provider=self.mock_key_provider)
         test_encryptor.bytes_read = aws_encryption_sdk.internal.defaults.MAX_NON_FRAMED_SIZE
+        test_encryptor._StreamEncryptor__unframed_plaintext_cache = pt_stream
+
         with six.assertRaisesRegex(self, SerializationError, "Source too large for non-framed message"):
             test_encryptor._read_bytes_to_non_framed_body(5)
 


### PR DESCRIPTION
*Issue #, if available:* #103 

*Description of changes:*
Remove the requirement for `source_stream.tell()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
