### PR TITLE
Migrate unit/test_deserialize.py from unittest from pytest

### DIFF
--- a/test/unit/test_deserialize.py
+++ b/test/unit/test_deserialize.py
@@ -79,7 +79,7 @@ class TestDeserialize(object):
         # Set up mock verifier
         self.mock_verifier = MagicMock()
         self.mock_verifier.update.return_value = None
-        yield 
+        yield
         # Run tearDown
         self.mock_decrypt_patcher.stop()
         self.mock_deserialize_ec_patcher.stop()

--- a/test/unit/test_deserialize.py
+++ b/test/unit/test_deserialize.py
@@ -15,7 +15,6 @@ import io
 import struct
 
 import pytest
-import six
 from cryptography.exceptions import InvalidTag
 from mock import MagicMock, patch, sentinel
 
@@ -80,8 +79,8 @@ class TestDeserialize(object):
         # Set up mock verifier
         self.mock_verifier = MagicMock()
         self.mock_verifier.update.return_value = None
-
-    def tearDown(self):
+        yield 
+        # Run tearDown
         self.mock_decrypt_patcher.stop()
         self.mock_deserialize_ec_patcher.stop()
 

--- a/test/unit/test_deserialize.py
+++ b/test/unit/test_deserialize.py
@@ -13,7 +13,6 @@
 """Unit test suite for aws_encryption_sdk.deserialize"""
 import io
 import struct
-import unittest
 
 import pytest
 import six
@@ -56,8 +55,9 @@ def test_deserialize_tag():
     assert parsed_tag == tag
 
 
-class TestDeserialize(unittest.TestCase):
-    def setUp(self):
+class TestDeserialize(object):
+    @pytest.fixture(autouse=True)
+    def apply_fixtures(self):
         self.mock_wrapping_algorithm = MagicMock()
         self.mock_wrapping_algorithm.algorithm.iv_len = VALUES["iv_len"]
 
@@ -109,29 +109,32 @@ class TestDeserialize(unittest.TestCase):
             as expected for a valid header.
         """
         self.mock_decrypt.side_effect = InvalidTag()
-        with six.assertRaisesRegex(self, SerializationError, "Header authorization failed"):
+        with pytest.raises(SerializationError) as excinfo:
             aws_encryption_sdk.internal.formatting.deserialize.validate_header(
                 header=VALUES["deserialized_header_block"],
                 header_auth=VALUES["deserialized_header_auth_block"],
                 raw_header=VALUES["header"],
                 data_key=VALUES["data_key_obj"],
             )
+        excinfo.match("Header authorization failed")
 
     def test_deserialize_header_unknown_object_type(self):
         """Validate that the deserialize_header function behaves
             as expected for an unknown object type.
         """
-        with six.assertRaisesRegex(self, NotSupportedError, "Unsupported type *"):
+        with pytest.raises(NotSupportedError) as excinfo:
             stream = io.BytesIO(VALUES["serialized_header_invalid_object_type"])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
+        excinfo.match("Unsupported type *")
 
     def test_deserialize_header_unknown_version(self):
         """Validate that the deserialize_header function behaves
             as expected for an unknown message version.
         """
-        with six.assertRaisesRegex(self, NotSupportedError, "Unsupported version *"):
+        with pytest.raises(NotSupportedError) as excinfo:
             stream = io.BytesIO(VALUES["serialized_header_invalid_version"])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
+        excinfo.match("Unsupported version *")
 
     @patch("aws_encryption_sdk.internal.formatting.deserialize.AlgorithmSuite.get_by_id")
     def test_deserialize_header_unsupported_data_encryption_algorithm(self, mock_algorithm_get):
@@ -141,9 +144,10 @@ class TestDeserialize(unittest.TestCase):
         mock_unsupported_algorithm = MagicMock()
         mock_unsupported_algorithm.allowed = False
         mock_algorithm_get.return_value = mock_unsupported_algorithm
-        with six.assertRaisesRegex(self, NotSupportedError, "Unsupported algorithm *"):
+        with pytest.raises(NotSupportedError) as excinfo:
             stream = io.BytesIO(VALUES["serialized_header_disallowed_algorithm"])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
+        excinfo.match("Unsupported algorithm *")
 
     @patch("aws_encryption_sdk.internal.formatting.deserialize.AlgorithmSuite.get_by_id")
     def test_deserialize_header_unknown_data_encryption_algorithm(self, mock_algorithm_get):
@@ -151,55 +155,59 @@ class TestDeserialize(unittest.TestCase):
             as expected for an unknown algorithm.
         """
         mock_algorithm_get.side_effect = KeyError()
-        with six.assertRaisesRegex(self, UnknownIdentityError, "Unknown algorithm *"):
+        with pytest.raises(UnknownIdentityError) as excinfo:
             stream = io.BytesIO(VALUES["serialized_header_invalid_algorithm"])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
+        excinfo.match("Unknown algorithm *")
 
     def test_deserialize_header_unknown_content_type(self):
         """Validate that the deserialize_header function behaves
             as expected for an unknown content type.
         """
-        with six.assertRaisesRegex(self, UnknownIdentityError, "Unknown content type *"):
+        with pytest.raises(UnknownIdentityError) as excinfo:
             stream = io.BytesIO(VALUES["serialized_header_unknown_content_type"])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
+        excinfo.match("Unknown content type *")
 
     def test_deserialize_header_invalid_reserved_space(self):
         """Validate that the deserialize_header function behaves
             as expected for an invalid value in the reserved
             space (formerly content AAD).
         """
-        with six.assertRaisesRegex(
-            self, SerializationError, "Content AAD length field is currently unused, its value must be always 0"
-        ):
+        with pytest.raises(SerializationError) as excinfo:
             stream = io.BytesIO(VALUES["serialized_header_bad_reserved_space"])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
+        excinfo.match("Content AAD length field is currently unused, its value must be always 0")
 
     def test_deserialize_header_bad_iv_len(self):
         """Validate that the deserialize_header function behaves
             as expected for bad IV length (incompatible with
             specified algorithm).
         """
-        with six.assertRaisesRegex(self, SerializationError, "Specified IV length *"):
+        with pytest.raises(SerializationError) as excinfo:
             stream = io.BytesIO(VALUES["serialized_header_bad_iv_len"])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
+        excinfo.match("Specified IV length *")
 
     def test_deserialize_header_framed_bad_frame_length(self):
         """Validate that the deserialize_header function behaves
             as expected for bad frame length values (greater than
             the default maximum).
         """
-        with six.assertRaisesRegex(self, SerializationError, "Specified frame length larger than allowed maximum: *"):
+        with pytest.raises(SerializationError) as excinfo:
             stream = io.BytesIO(VALUES["serialized_header_bad_frame_len"])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
+        excinfo.match("Specified frame length larger than allowed maximum: *")
 
     def test_deserialize_header_non_framed_bad_frame_length(self):
         """Validate that the deserialize_header function behaves
             as expected for bad frame length values for non-framed
             messages (non-zero).
         """
-        with six.assertRaisesRegex(self, SerializationError, "Non-zero frame length found for non-framed message"):
+        with pytest.raises(SerializationError) as excinfo:
             stream = io.BytesIO(VALUES["serialized_non_framed_header_bad_frame_len"])
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_header(stream)
+        excinfo.match("Non-zero frame length found for non-framed message")
 
     def test_deserialize_header_valid(self):
         """Validate that the deserialize_header function behaves
@@ -247,10 +255,11 @@ class TestDeserialize(unittest.TestCase):
             behaves as expected for a valid final body frame.
         """
         stream = io.BytesIO(VALUES["serialized_final_frame_bad_length"])
-        with six.assertRaisesRegex(self, SerializationError, "Invalid final frame length: *"):
+        with pytest.raises(SerializationError) as excinfo:
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_frame(
                 stream=stream, header=VALUES["deserialized_header_frame"]
             )
+        excinfo.match("Invalid final frame length: *")
 
     def test_deserialize_footer_no_verifier(self):
         """Vaidate that the deserialize_footer function behaves
@@ -275,8 +284,9 @@ class TestDeserialize(unittest.TestCase):
             with no footer.
         """
         stream = io.BytesIO(b"")
-        with six.assertRaisesRegex(self, SerializationError, "No signature found in message"):
+        with pytest.raises(SerializationError) as excinfo:
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_footer(stream, self.mock_verifier)
+        excinfo.match("No signature found in message")
 
     @patch("aws_encryption_sdk.internal.formatting.deserialize.struct")
     def test_unpack_values(self, mock_struct):
@@ -328,15 +338,16 @@ class TestDeserialize(unittest.TestCase):
         )
 
     def test_deserialize_wrapped_key_symmetric_wrapping_key_mismatch(self):
-        with six.assertRaisesRegex(self, SerializationError, "Master Key mismatch for wrapped data key"):
+        with pytest.raises(SerializationError) as excinfo:
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_wrapped_key(
                 wrapping_algorithm=self.mock_wrapping_algorithm,
                 wrapping_key_id=b"asifuhasjaskldjfhlsakdfj",
                 wrapped_encrypted_key=VALUES["wrapped_keys"]["structures"]["wrapped_encrypted_data_key_asymmetric"],
             )
+        excinfo.match("Master Key mismatch for wrapped data key")
 
     def test_deserialize_wrapped_key_symmetric_wrapping_algorithm_incomplete_info(self):
-        with six.assertRaisesRegex(self, SerializationError, "Malformed key info: key info missing data"):
+        with pytest.raises(SerializationError) as excinfo:
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_wrapped_key(
                 wrapping_algorithm=self.mock_wrapping_algorithm,
                 wrapping_key_id=VALUES["wrapped_keys"]["raw"]["key_info"],
@@ -344,9 +355,10 @@ class TestDeserialize(unittest.TestCase):
                     "wrapped_encrypted_data_key_symmetric_incomplete_info"
                 ],
             )
+        excinfo.match("Malformed key info: key info missing data")
 
     def test_deserialize_wrapped_key_symmetric_wrapping_algorithm_iv_len_mismatch(self):
-        with six.assertRaisesRegex(self, SerializationError, "Wrapping AlgorithmSuite mismatch for wrapped data key"):
+        with pytest.raises(SerializationError) as excinfo:
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_wrapped_key(
                 wrapping_algorithm=self.mock_wrapping_algorithm,
                 wrapping_key_id=VALUES["wrapped_keys"]["raw"]["key_info"],
@@ -354,9 +366,10 @@ class TestDeserialize(unittest.TestCase):
                     "wrapped_encrypted_data_key_symmetric_bad_iv_len"
                 ],
             )
+        excinfo.match("Wrapping AlgorithmSuite mismatch for wrapped data key")
 
     def test_deserialize_wrapped_key_symmetric_wrapping_algorithm_incomplete_iv(self):
-        with six.assertRaisesRegex(self, SerializationError, "Malformed key info: incomplete iv"):
+        with pytest.raises(SerializationError) as excinfo:
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_wrapped_key(
                 wrapping_algorithm=self.mock_wrapping_algorithm,
                 wrapping_key_id=VALUES["wrapped_keys"]["raw"]["key_info"],
@@ -364,9 +377,10 @@ class TestDeserialize(unittest.TestCase):
                     "wrapped_encrypted_data_key_symmetric_incomplete_iv"
                 ],
             )
+        excinfo.match("Malformed key info: incomplete iv")
 
     def test_deserialize_wrapped_key_symmetric_wrapping_algorithm_incomplete_tag(self):
-        with six.assertRaisesRegex(self, SerializationError, "Malformed key info: incomplete ciphertext or tag"):
+        with pytest.raises(SerializationError) as excinfo:
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_wrapped_key(
                 wrapping_algorithm=self.mock_wrapping_algorithm,
                 wrapping_key_id=VALUES["wrapped_keys"]["raw"]["key_info"],
@@ -374,9 +388,10 @@ class TestDeserialize(unittest.TestCase):
                     "wrapped_encrypted_data_key_symmetric_incomplete_tag"
                 ],
             )
+        excinfo.match("Malformed key info: incomplete ciphertext or tag")
 
     def test_deserialize_wrapped_key_symmetric_wrapping_algorithm_incomplete_tag2(self):
-        with six.assertRaisesRegex(self, SerializationError, "Malformed key info: incomplete ciphertext or tag"):
+        with pytest.raises(SerializationError) as excinfo:
             aws_encryption_sdk.internal.formatting.deserialize.deserialize_wrapped_key(
                 wrapping_algorithm=self.mock_wrapping_algorithm,
                 wrapping_key_id=VALUES["wrapped_keys"]["raw"]["key_info"],
@@ -384,3 +399,4 @@ class TestDeserialize(unittest.TestCase):
                     "wrapped_encrypted_data_key_symmetric_incomplete_tag2"
                 ],
             )
+        excinfo.match("Malformed key info: incomplete ciphertext or tag")


### PR DESCRIPTION
*Issue #, if available:* #99 

*Description of changes:*
Migrated "test/unit/test_deserialize.py" from unittest to pytest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
