### PR TITLE
Migrate unit/test_encryption_context.py from unittest to pytest

### DIFF
--- a/test/unit/test_encryption_context.py
+++ b/test/unit/test_encryption_context.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 """Unit test suite for aws_encryption_sdk.internal.formatting.encryption_context"""
 import pytest
-import six
 
 import aws_encryption_sdk.internal.defaults
 import aws_encryption_sdk.internal.formatting.encryption_context


### PR DESCRIPTION
*Issue #, if available:* #99

*Description of changes:*
Migrated "test/unit/test_encryption_context.py" from unittest to pytest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
