### PR TITLE
Migrate unit/test_util_str_ops.py from unittest to pytest

### DIFF
--- a/test/unit/test_util_str_ops.py
+++ b/test/unit/test_util_str_ops.py
@@ -13,7 +13,6 @@
 # language governing permissions and limitations under the License.
 """Test suite for aws_encryption_sdk.internal.str_ops"""
 import codecs
-import unittest
 
 import pytest
 
@@ -22,7 +21,7 @@ import aws_encryption_sdk.internal.str_ops
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-class TestStrOps(unittest.TestCase):
+class TestStrOps(object):
     def test_to_str_str2str(self):
         test = aws_encryption_sdk.internal.str_ops.to_str("asdf")
         assert test == "asdf"


### PR DESCRIPTION
*Issue #, if available:* #99

*Description of changes:*
Migrated "test/unit/test_util_str_ops.py" from unittest to pytest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
