### PR TITLE
Convert pylintrc files from short IDs to readable names

### DIFF
--- a/decrypt_oracle/src/pylintrc
+++ b/decrypt_oracle/src/pylintrc
@@ -1,11 +1,9 @@
 [MESSAGES CONTROL]
-# Disabling messages that we either don't care about
-# for tests or are necessary to break for tests.
-#
-# C0330 : bad-continuation (we let black handle this)
-# C0412 : ungrouped-imports (we let isort handle this)
-# R0205 : useless-object-inheritance (we need to support Python 2, so no, not useless)
-disable = C0330, C0412, R0205
+# Disabling messages that we either don't care about for tests or are necessary to break for tests.
+disable =
+    bad-continuation,  # we let black handle this
+    ungrouped-imports,  # we let isort handle this
+    useless-object-inheritance,  # we need to support Python 2, so no, not useless
 
 [FORMAT]
 max-line-length = 120

--- a/examples/src/pylintrc
+++ b/examples/src/pylintrc
@@ -1,20 +1,19 @@
 [MESSAGE CONTROL]
 # Disabling messages that either we don't care about we intentionally break.
-#
-# C0103 : invalid-name (we prefer long, descriptive, names for examples)
-# C0330 : bad-continuation (we let black handle this)
-# C0412 : ungrouped-imports (we let isort handle this)
-# E1101 : no-member (breaks with attrs)
-# R0201 : no-self-use (interesting to keep in mind for later refactoring, but not blocking)
-# R0205 : useless-object-inheritance (we need to support Python 2, so no, not useless)
-# R0801 : duplicate-code (some examples may be similar)
-# R0903 : too-few-public-methods (does not allow value stores)
-# R0914 : too-many-locals (examples may sometimes have more locals defined for clarity than would be appropriate in code)
-# R1705 : no-else-return (we omit this on purpose for brevity where it would add no value)
-# W0201 : attribute-defined-outside-init (breaks with attrs_post_init)
-# W0223 : abstract-method (throws false positives on io.BaseIO grandchildren)
-# W0621 : redefined-outer-name (we do this on purpose in multiple places)
-disable = C0103, C0330, C0412, E1101, R0201, R0205, R0801, R0903, R0914, R1705, W0201, W0223, W0621
+disable =
+    invalid-name,  # we prefer long, descriptive, names for examples
+    bad-continuation,  # we let black handle this
+    ungrouped-imports,  # we let isort handle this
+    no-member,  # breaks with attrs
+    no-self-use,  # interesting to keep in mind for later refactoring, but not blocking
+    useless-object-inheritance,  # we need to support Python 2, so no, not useless
+    duplicate-code,  # some examples may be similar
+    too-few-public-methods,  # does not allow value stores
+    too-many-locals,  # examples may sometimes have more locals defined for clarity than would be appropriate in code
+    no-else-return,  # we omit this on purpose for brevity where it would add no value
+    attribute-defined-outside-init,  # breaks with attrs_post_init
+    abstract-method,  # throws false positives on io.BaseIO grandchildren
+    redefined-outer-name,  # we do this on purpose in multiple places
 
 [BASIC]
 # Allow function names up to 50 characters

--- a/examples/test/pylintrc
+++ b/examples/test/pylintrc
@@ -1,16 +1,14 @@
 [MESSAGES CONTROL]
-# Disabling messages that we either don't care about
-# for tests or are necessary to break for tests.
-#
-# C0103 : invalid-name (we prefer long, descriptive, names for tests)
-# C0111 : missing-docstring (we don't write docstrings for tests)
-# C0413 : wrong-import-position (similar to E0401, pylint does not appear to identify
-#           unknown modules as non-standard-library. flake8 tests for this as well
-#           and does treat them properly)
-# E0401 : import-error (because the examples are not actually in a module, sys.path
-#           is patched to find tests and test utils. pylint does not recognize this)
-# R0801 : duplicate-code (tests for similar things tend to be similar)
-disable = C0103, C0111, C0413, E0401, R0801
+# Disabling messages that we either don't care about for tests or are necessary to break for tests.
+disable =
+    invalid-name,  # we prefer long, descriptive, names for tests
+    missing-docstring,  # we don't write docstrings for tests
+    wrong-import-position,  # similar to E0401, pylint does not appear to identify
+                            # unknown modules as non-standard-library. flake8 tests for this as well
+                            # and does treat them properly
+    import-error,  # because the examples are not actually in a module, sys.path
+                   # is patched to find tests and test utils. pylint does not recognize this
+    duplicate-code,  # tests for similar things tend to be similar
 
 [VARIABLES]
 additional-builtins = raw_input

--- a/src/pylintrc
+++ b/src/pylintrc
@@ -1,17 +1,16 @@
 [MESSAGE CONTROL]
 # Disabling messages that either we don't care about we intentionally break.
-#
-# C0330 : bad-continuation (we let black handle this)
-# C0412 : ungrouped-imports (we let isort handle this)
-# E1101 : no-member (breaks with attrs)
-# R0201 : no-self-use (interesting to keep in mind for later refactoring, but not blocking)
-# R0205 : useless-object-inheritance (we need to support Python 2, so no, not useless)
-# R0903 : too-few-public-methods (does not allow value stores)
-# R1705 : no-else-return (we omit this on purpose for brevity where it would add no value)
-# W0201 : attribute-defined-outside-init (breaks with attrs_post_init)
-# W0223 : abstract-method (throws false positives on io.BaseIO grandchildren)
-# W0621 : redefined-outer-name (we do this on purpose in multiple places)
-disable = C0330, C0412, E1101, R0201, R0205, R0903, R1705, W0201, W0223, W0621
+disable =
+    bad-continuation,  # we let isort handle this
+    ungrouped-imports,  # we let isort handle this
+    no-member,  # breaks with attrs
+    no-self-use,  # interesting to keep in mind for later refactoring, but not blocking
+    useless-object-inheritance,  # we need to support Python 2, so no, not useless
+    too-few-public-methods,  # does not allow value stores
+    no-else-return,  # we omit this on purpose for brevity where it would add no value
+    attribute-defined-outside-init,  # breaks with attrs_post_init
+    abstract-method,  # throws false positives on io.BaseIO grandchildren
+    redefined-outer-name,  # we do this on purpose in multiple places
 
 [BASIC]
 # Allow function names up to 50 characters

--- a/test/pylintrc
+++ b/test/pylintrc
@@ -1,27 +1,25 @@
 [MESSAGES CONTROL]
-# Disabling messages that we either don't care about
-# for tests or are necessary to break for tests.
-#
-# C0103 : invalid-name (we prefer long, descriptive, names for tests)
-# C0111 : missing-docstring (we don't write docstrings for tests)
-# C0330 : bad-continuation (we let black handle this)
-# C0412 : ungrouped-imports (we let isort handle this)
-# E0110 : abstract-class-instantiated (we do this on purpose to test that they are enforced)
-# E1101 : no-member (raised on patched objects with mock checks)
-# R0201 : no-self-use (common pattern when using unittest: can be enabled once all tests are refactored to pytest)
-# R0205 : useless-object-inheritance (we need to support Python 2, so no, not useless)
-# R0801 : duplicate-code (unit tests for similar things tend to be similar)
-# R0902 : too-many-instance-attributes (common pattern when using unittest: can be enabled once all tests are refactored to pytest)
-# R0903 : too-few-public-methods (common when setting up mock classes)
-# R0904 : too-many-public-methods (common pattern when using unittest: can be enabled once all tests are refactored to pytest)
-# R0914 : too-many-locals (common pattern when using unittest: can be enabled once all tests are refactored to pytest)
-# R0915 : too-many-statements (common pattern when using unittest: can be enabled once all tests are refactored to pytest)
-# W0201 : attribute-defined-outside-init (broken by some unittest monkeypatching: can be enabled once all tests are refactored to pytest)
-# W0212 : protected-access (raised when calling _ methods)
-# W0223 : abstract-method (we do this on purpose to test that they are enforced)
-# W0621 : redefined-outer-name (raised when using pytest-mock)
-# W0613 : unused-argument (raised when patches are needed but not called)
-disable = C0103, C0111, C0330, C0412, E0110, E1101, R0201, R0205, R0801, R0902, R0903, R0904, R0914, R0915, W0201, W0212, W0223, W0621, W0613
+# Disabling messages that we either don't care about for tests or are necessary to break for tests.
+disable =
+    invalid-name,  # we prefer long, descriptive, names for tests
+    missing-docstring,  # we don't write docstrings for tests
+    bad-continuation,  # we let black handle this
+    ungrouped-imports,  # we let isort handle this
+    abstract-class-instantiated,  # we do this on purpose to test that they are enforced
+    no-member,  # raised on patched objects with mock checks
+    no-self-use,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
+    useless-object-inheritance,  # we need to support Python 2, so no, not useless
+    duplicate-code,  # unit tests for similar things tend to be similar
+    too-many-instance-attributes,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
+    too-few-public-methods,  # common when setting up mock classes
+    too-many-public-methods,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
+    too-many-locals,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
+    too-many-statements,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
+    attribute-defined-outside-init,  # broken by some unittest monkeypatching: can be enabled once all tests are refactored to pytest
+    protected-access,  # raised when calling _ methods
+    abstract-method,  # we do this on purpose to test that they are enforced
+    redefined-outer-name,  # raised when using pytest-mock
+    unused-argument,  # raised when patches are needed but not called
 
 [VARIABLES]
 additional-builtins = raw_input

--- a/test/pylintrc
+++ b/test/pylintrc
@@ -7,18 +7,17 @@ disable =
     ungrouped-imports,  # we let isort handle this
     abstract-class-instantiated,  # we do this on purpose to test that they are enforced
     no-member,  # raised on patched objects with mock checks
-    no-self-use,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
+    no-self-use,  # common pattern when using pytest classes: can be enabled once all tests are refactored to pytest functions
     useless-object-inheritance,  # we need to support Python 2, so no, not useless
     duplicate-code,  # unit tests for similar things tend to be similar
-    too-many-instance-attributes,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
+    too-many-instance-attributes,  # common pattern when using pytest classes: can be enabled once all tests are refactored to pytest functions
     too-few-public-methods,  # common when setting up mock classes
-    too-many-public-methods,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
-    too-many-locals,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
-    too-many-statements,  # common pattern when using unittest: can be enabled once all tests are refactored to pytest
-    attribute-defined-outside-init,  # broken by some unittest monkeypatching: can be enabled once all tests are refactored to pytest
+    too-many-public-methods,  # common pattern when using pytest classes: can be enabled once all tests are refactored to pytest functions
+    too-many-statements,  # common pattern when using pytest classes: can be enabled once all tests are refactored to pytest functions
+    attribute-defined-outside-init,  # broken by some pytest classes monkeypatching: can be enabled once all tests are refactored to pytest functions
     protected-access,  # raised when calling _ methods
     abstract-method,  # we do this on purpose to test that they are enforced
-    redefined-outer-name,  # raised when using pytest-mock
+    redefined-outer-name,  # raised when using decorators
     unused-argument,  # raised when patches are needed but not called
 
 [VARIABLES]

--- a/test_vector_handlers/src/pylintrc
+++ b/test_vector_handlers/src/pylintrc
@@ -1,11 +1,9 @@
 [MESSAGES CONTROL]
-# Disabling messages that we either don't care about
-# for tests or are necessary to break for tests.
-#
-# C0330 : bad-continuation (we let black handle this)
-# C0412 : ungrouped-imports (we let isort handle this)
-# R0205 : useless-object-inheritance (we need to support Python 2, so no, not useless)
-disable = C0330, C0412, R0205
+# Disabling messages that we either don't care about for tests or are necessary to break for tests.
+disable =
+    bad-continuation,  # we let black handle this
+    ungrouped-imports,  # we let isort handle this
+    useless-object-inheritance,  # we need to support Python 2, so no, not useless
 
 [FORMAT]
 max-line-length = 120


### PR DESCRIPTION
*Description of changes:*
Convert pylintrc files from short IDs to readable names

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
