### PR TITLE
reorganize examples cross-imports to simplify tests

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -10,16 +10,4 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""Unit test suite for the basic data key caching example in the AWS-hosted documentation."""
-import pytest
-
-from ..src.data_key_caching_basic import encrypt_with_caching
-from .examples_test_utils import get_cmk_arn
-
-
-pytestmark = [pytest.mark.examples]
-
-
-def test_encrypt_with_caching():
-    cmk_arn = get_cmk_arn()
-    encrypt_with_caching(kms_cmk_arn=cmk_arn, max_age_in_cache=10.0, cache_capacity=10)
+"""Stub to allow relative imports of examples from tests."""

--- a/examples/test/examples_test_utils.py
+++ b/examples/test/examples_test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -10,16 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""Unit test suite for the basic data key caching example in the AWS-hosted documentation."""
-import pytest
+"""Helper utilities for use while testing examples."""
+import os
+import sys
 
-from ..src.data_key_caching_basic import encrypt_with_caching
-from .examples_test_utils import get_cmk_arn
+os.environ["AWS_ENCRYPTION_SDK_EXAMPLES_TESTING"] = "yes"
+sys.path.extend([os.sep.join([os.path.dirname(__file__), "..", "..", "test", "integration"])])
 
-
-pytestmark = [pytest.mark.examples]
-
-
-def test_encrypt_with_caching():
-    cmk_arn = get_cmk_arn()
-    encrypt_with_caching(kms_cmk_arn=cmk_arn, max_age_in_cache=10.0, cache_capacity=10)
+from integration_test_utils import get_cmk_arn  # noqa pylint: disable=unused-import,import-error

--- a/examples/test/pylintrc
+++ b/examples/test/pylintrc
@@ -6,8 +6,6 @@ disable =
     wrong-import-position,  # similar to E0401, pylint does not appear to identify
                             # unknown modules as non-standard-library. flake8 tests for this as well
                             # and does treat them properly
-    import-error,  # because the examples are not actually in a module, sys.path
-                   # is patched to find tests and test utils. pylint does not recognize this
     duplicate-code,  # tests for similar things tend to be similar
 
 [VARIABLES]

--- a/examples/test/test_i_basic_encryption.py
+++ b/examples/test/test_i_basic_encryption.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -12,20 +12,12 @@
 # language governing permissions and limitations under the License.
 """Unit test suite for the Strings examples in the AWS-hosted documentation."""
 import os
-import sys
-
-sys.path.extend(
-    [  # noqa
-        os.sep.join([os.path.dirname(__file__), "..", "..", "test", "integration"]),
-        os.sep.join([os.path.dirname(__file__), "..", "src"]),
-    ]
-)
 
 import botocore.session
 import pytest
 
-from basic_encryption import cycle_string
-from integration_test_utils import get_cmk_arn
+from ..src.basic_encryption import cycle_string
+from .examples_test_utils import get_cmk_arn
 
 
 pytestmark = [pytest.mark.examples]

--- a/examples/test/test_i_basic_file_encryption_with_multiple_providers.py
+++ b/examples/test/test_i_basic_file_encryption_with_multiple_providers.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -12,21 +12,13 @@
 # language governing permissions and limitations under the License.
 """Unit test suite for the Bytes Streams Multiple Providers examples in the AWS-hosted documentation."""
 import os
-import sys
-
-sys.path.extend(
-    [  # noqa
-        os.sep.join([os.path.dirname(__file__), "..", "..", "test", "integration"]),
-        os.sep.join([os.path.dirname(__file__), "..", "src"]),
-    ]
-)
 import tempfile
 
 import botocore.session
 import pytest
 
-from basic_file_encryption_with_multiple_providers import cycle_file
-from integration_test_utils import get_cmk_arn
+from ..src.basic_file_encryption_with_multiple_providers import cycle_file
+from .examples_test_utils import get_cmk_arn
 
 
 pytestmark = [pytest.mark.examples]

--- a/examples/test/test_i_basic_file_encryption_with_raw_key_provider.py
+++ b/examples/test/test_i_basic_file_encryption_with_raw_key_provider.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -12,14 +12,11 @@
 # language governing permissions and limitations under the License.
 """Unit test suite for the Bytes Streams examples in the AWS-hosted documentation."""
 import os
-import sys
-
-sys.path.extend([os.sep.join([os.path.dirname(__file__), "..", "src"])])  # noqa
 import tempfile
 
 import pytest
 
-from basic_file_encryption_with_raw_key_provider import cycle_file
+from ..src.basic_file_encryption_with_raw_key_provider import cycle_file
 
 
 pytestmark = [pytest.mark.examples]


### PR DESCRIPTION
*Description of changes:*
In preparation for #156, I realized that I hadn't given these examples tests the same treatment that I gave the DDB encryption client and Pipeformer.

These changes make writing tests for examples much simpler and less finicky.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
