### PR TITLE
Fixed KMS master key provider tests when default AWS region is configured

### DIFF
--- a/test/unit/test_providers_kms_master_key_provider.py
+++ b/test/unit/test_providers_kms_master_key_provider.py
@@ -23,6 +23,19 @@ from aws_encryption_sdk.key_providers.kms import KMSMasterKey, KMSMasterKeyProvi
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
+@pytest.fixture(autouse=True, params=[True, False], ids=["default region", "no default region"])
+def patch_default_region(request, monkeypatch):
+    """Run all tests in this module both with a default region set and no default region set.
+
+    This ensures that we do not regress on default region handling.
+    https://github.com/aws/aws-encryption-sdk-python/issues/31
+    """
+    if request.param:
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+    else:
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+
 def test_init_with_regionless_key_ids_and_region_names():
     key_ids = ("alias/key_1",)
     region_names = ("test-region-1",)


### PR DESCRIPTION
This fixes issue #31, in which users who have configured a default AWS region (either via ~/.aws/config or via environment variable) will experience failing tests for `KMSMasterKeyProvider`. I tried to keep the tests mostly unchanged, but in some cases I elected to simply skip them since the test didn't provide much value if there was already a default value configured. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
