### PR TITLE
Fixed issue #55

### DIFF
--- a/src/aws_encryption_sdk/internal/formatting/encryption_context.py
+++ b/src/aws_encryption_sdk/internal/formatting/encryption_context.py
@@ -47,9 +47,15 @@ def assemble_content_aad(message_id, aad_content_string, seq_num, length):
     return struct.pack(fmt, message_id, aad_content_string.value, seq_num, length)
 
 
-# help function to simplify code
-# this is necessary to pass flake8
+def _key_or_value_too_large(encryption_context_list):
+    """Helper method to check whether a key or value are too long."""
+    longest_key = max(encryption_context_list, key=lambda x: len(x[0]))[0]
+    longest_value = max(encryption_context_list, key=lambda x: len(x[1]))[1]
+    return len(longest_key) > 2 ** 16 - 1 or len(longest_value) > 2 ** 16 - 1
+
+
 def _serialize_encryption_context_list(encryption_context_list, serialized_context):
+    """Helper function to serialize the list of encryption context key-value pairs."""
     for key, value in sorted(encryption_context_list, key=lambda x: x[0]):
         try:
             serialized_context.extend(
@@ -64,11 +70,14 @@ def _serialize_encryption_context_list(encryption_context_list, serialized_conte
         # we check to make sure that we return the right type of error message for an overly long key or value
         except struct.error as struct_error:
             message = str(struct_error)
+            # a key or value were too long and struct gave us the expected error
             if message == "'H' format requires 0 <= number <= 65535":
-                # the key or value were too large
+                raise SerializationError("Key or Value are too large.  Maximum length is 65535")
+            # a key or value were too long and struct's error message is different (maybe an update)
+            if _key_or_value_too_large(encryption_context_list):
                 raise SerializationError("Key or Value are too large.  Maximum length is 65535")
             # else we can just raise the struct error as it was (unknown)
-            raise struct_error
+            raise SerializationError("Unknown Error with struct pack.  Could not serialize key or value")
         if len(serialized_context) > aws_encryption_sdk.internal.defaults.MAX_BYTE_ARRAY_SIZE:
             raise SerializationError("The serialized context is too large.")
     return bytes(serialized_context)

--- a/src/aws_encryption_sdk/internal/formatting/encryption_context.py
+++ b/src/aws_encryption_sdk/internal/formatting/encryption_context.py
@@ -47,6 +47,33 @@ def assemble_content_aad(message_id, aad_content_string, seq_num, length):
     return struct.pack(fmt, message_id, aad_content_string.value, seq_num, length)
 
 
+# help function to simplify code
+# this is necessary to pass flake8
+def _serialize_encryption_context_list(encryption_context_list, serialized_context):
+    for key, value in sorted(encryption_context_list, key=lambda x: x[0]):
+        try:
+            serialized_context.extend(
+                struct.pack(
+                    ">H{key_size}sH{value_size}s".format(key_size=len(key), value_size=len(value)),
+                    len(key),
+                    key,
+                    len(value),
+                    value,
+                )
+            )
+        # we check to make sure that we return the right type of error message for an overly long key or value
+        except struct.error as struct_error:
+            message = str(struct_error)
+            if message == "'H' format requires 0 <= number <= 65535":
+                # the key or value were too large
+                raise SerializationError("Key or Value are too large.  Maximum length is 65535")
+            # else we can just raise the struct error as it was (unknown)
+            raise struct_error
+        if len(serialized_context) > aws_encryption_sdk.internal.defaults.MAX_BYTE_ARRAY_SIZE:
+            raise SerializationError("The serialized context is too large.")
+    return bytes(serialized_context)
+
+
 def serialize_encryption_context(encryption_context):
     """Serializes the contents of a dictionary into a byte string.
 
@@ -80,30 +107,7 @@ def serialize_encryption_context(encryption_context):
             raise SerializationError(
                 "Cannot encode dictionary key or value using {}.".format(aws_encryption_sdk.internal.defaults.ENCODING)
             )
-
-    for key, value in sorted(encryption_context_list, key=lambda x: x[0]):
-        try:
-            serialized_context.extend(
-                struct.pack(
-                    ">H{key_size}sH{value_size}s".format(key_size=len(key), value_size=len(value)),
-                    len(key),
-                    key,
-                    len(value),
-                    value,
-                )
-            )
-        # we check to make sure that we return the right type of error message for an overly long key or value
-        except struct.error as struct_error:
-            message = str(struct_error)
-            if message == "'H' format requires 0 <= number <= 65535":
-                # the key or value were too large
-                raise SerializationError("Key or Value are too large.  Maximum is 2^16-1 (equivalent to \xff\xff).")
-            else:
-                # unknown struct error
-                raise struct_error 
-        if len(serialized_context) > aws_encryption_sdk.internal.defaults.MAX_BYTE_ARRAY_SIZE:
-            raise SerializationError("The serialized context is too large.")
-    return bytes(serialized_context)
+    return _serialize_encryption_context_list(encryption_context_list, serialized_context)
 
 
 def read_short(source, offset):

--- a/test/unit/test_encryption_context.py
+++ b/test/unit/test_encryption_context.py
@@ -190,7 +190,19 @@ class TestEncryptionContext(object):
             serialized_encryption_context=b""
         )
         assert test == {}
+
     # important to not have autouse=true with a mock
+    # these three tests make sure that whether a key or value or both are too long
+    # we throw the right type of serialization error and not the struct.error
+    # from struct.pack()
+    def test_serialize_encryption_context_key_too_long(self):
+        dictionary = {"0"*2**16:"short"}
+        aws_encryption_sdk.internal.formatting.encryption_context.serialize_encryption_context(dictionary)
+
+    def test_serialize_encryption_context_value_too_long(self):
+        dictionary = {"short":"0"*2**16}
+        aws_encryption_sdk.internal.formatting.encryption_context.serialize_encryption_context(dictionary)
+
     def test_serialize_encryption_context_key_value_too_long(self):
-        dictionary = {}
-        serialize.serialize_encryption_context(dictionary)
+        dictionary = {"0"*2**16:"0"*2**16}
+        aws_encryption_sdk.internal.formatting.encryption_context.serialize_encryption_context(dictionary)

--- a/test/unit/test_encryption_context.py
+++ b/test/unit/test_encryption_context.py
@@ -191,18 +191,11 @@ class TestEncryptionContext(object):
         )
         assert test == {}
 
-    # important to not have autouse=true with a mock
-    # these three tests make sure that whether a key or value or both are too long
+    # these three tests (in one function) make sure that whether a key or value or both are too long
     # we throw the right type of serialization error and not the struct.error
     # from struct.pack()
-    def test_serialize_encryption_context_key_too_long(self):
-        dictionary = {"0"*2**16:"short"}
-        aws_encryption_sdk.internal.formatting.encryption_context.serialize_encryption_context(dictionary)
-
-    def test_serialize_encryption_context_value_too_long(self):
-        dictionary = {"short":"0"*2**16}
-        aws_encryption_sdk.internal.formatting.encryption_context.serialize_encryption_context(dictionary)
-
     def test_serialize_encryption_context_key_value_too_long(self):
-        dictionary = {"0"*2**16:"0"*2**16}
-        aws_encryption_sdk.internal.formatting.encryption_context.serialize_encryption_context(dictionary)
+        for dictionary in [{"0" * 2 ** 16: "short"}, {"short": "0" * 2 ** 16}, {"0" * 2 ** 16: "0" * 2 ** 16}]:
+            with pytest.raises(SerializationError) as excinfo:
+                aws_encryption_sdk.internal.formatting.encryption_context.serialize_encryption_context(dictionary)
+            excinfo.match(r"Key or Value are too large.  Maximum length is 65535")

--- a/test/unit/test_encryption_context.py
+++ b/test/unit/test_encryption_context.py
@@ -190,3 +190,7 @@ class TestEncryptionContext(object):
             serialized_encryption_context=b""
         )
         assert test == {}
+    # important to not have autouse=true with a mock
+    def test_serialize_encryption_context_key_value_too_long(self):
+        dictionary = {}
+        serialize.serialize_encryption_context(dictionary)

--- a/test/unit/test_serialize.py
+++ b/test/unit/test_serialize.py
@@ -48,7 +48,6 @@ def test_serialize_frame_invalid_sequence_number(sequence_number, error_message)
 
     excinfo.match(error_message)
 
-
 class TestSerialize(object):
     @pytest.fixture(autouse=True)
     def apply_fixtures(self):

--- a/test/unit/test_serialize.py
+++ b/test/unit/test_serialize.py
@@ -48,6 +48,7 @@ def test_serialize_frame_invalid_sequence_number(sequence_number, error_message)
 
     excinfo.match(error_message)
 
+
 class TestSerialize(object):
     @pytest.fixture(autouse=True)
     def apply_fixtures(self):


### PR DESCRIPTION
Issue #55 

Serialization of encryption context will throw the correct type of error.  Also broke the serialization function into two using a helper function to improve readability and actually pass flake8 tests (which otherwise fail because of "too complex" which basically means it has too much if/else try/catch logic going on).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
No files moved or created, but they were edited.  This also contains a merge with Caitlin's PR so it is up to date.

