### PR TITLE
Updating frame length to be an optional parameter

### DIFF
--- a/src/aws_encryption_sdk/materials_managers/__init__.py
+++ b/src/aws_encryption_sdk/materials_managers/__init__.py
@@ -32,7 +32,7 @@ class EncryptionMaterialsRequest(object):
         If plaintext_rostream seek position is modified, it must be returned before leaving method.
 
     :param dict encryption_context: Encryption context passed to underlying master key provider and master keys
-    :param int frame_length: Frame length to be used while encrypting stream
+    :param int frame_length: Frame length to be used while encrypting stream (optional)
     :param plaintext_rostream: Source plaintext read-only stream (optional)
     :type plaintext_rostream: aws_encryption_sdk.internal.utils.streams.ROStream
     :param algorithm: Algorithm passed to underlying master key provider and master keys (optional)
@@ -41,7 +41,8 @@ class EncryptionMaterialsRequest(object):
     """
 
     encryption_context = attr.ib(validator=attr.validators.instance_of(dict))
-    frame_length = attr.ib(validator=attr.validators.instance_of(six.integer_types))
+    frame_length = attr.ib(default=None, validator=attr.validators.optional(
+        attr.validators.instance_of(six.integer_types)))
     plaintext_rostream = attr.ib(
         default=None, validator=attr.validators.optional(attr.validators.instance_of(ROStream))
     )

--- a/src/aws_encryption_sdk/materials_managers/caching.py
+++ b/src/aws_encryption_sdk/materials_managers/caching.py
@@ -24,7 +24,7 @@ from ..caches import (
 )
 from ..caches.base import CryptoMaterialsCache
 from ..exceptions import CacheKeyError
-from ..internal.defaults import MAX_BYTES_PER_KEY, MAX_MESSAGES_PER_KEY
+from ..internal.defaults import MAX_BYTES_PER_KEY, MAX_MESSAGES_PER_KEY, FRAME_LENGTH
 from ..internal.str_ops import to_bytes
 from ..key_providers.base import MasterKeyProvider
 from . import EncryptionMaterialsRequest
@@ -190,9 +190,15 @@ class CachingCryptoMaterialsManager(CryptoMaterialsManager):
         # Inner request strips any information about the plaintext from the actual request.
         # This is done because the resulting encryption materials may be used to encrypt
         #  multiple plaintexts.
+
+        if request.frame_length is None:
+            frame_length = FRAME_LENGTH
+        else:
+            frame_length = request.frame_length
+
         inner_request = EncryptionMaterialsRequest(
             encryption_context=request.encryption_context,
-            frame_length=request.frame_length,
+            frame_length=frame_length,
             algorithm=request.algorithm,
         )
         cache_key = build_encryption_materials_cache_key(partition=self.partition_name, request=inner_request)

--- a/src/aws_encryption_sdk/materials_managers/caching.py
+++ b/src/aws_encryption_sdk/materials_managers/caching.py
@@ -24,7 +24,7 @@ from ..caches import (
 )
 from ..caches.base import CryptoMaterialsCache
 from ..exceptions import CacheKeyError
-from ..internal.defaults import MAX_BYTES_PER_KEY, MAX_MESSAGES_PER_KEY, FRAME_LENGTH
+from ..internal.defaults import FRAME_LENGTH, MAX_BYTES_PER_KEY, MAX_MESSAGES_PER_KEY
 from ..internal.str_ops import to_bytes
 from ..key_providers.base import MasterKeyProvider
 from . import EncryptionMaterialsRequest


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-encryption-sdk-python/issues/175

*Description of changes:*
Making the frame_length parameter to option, setting default value (FRAME_LENGTH) if no frame_length is provided 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

