### PR TITLE
update flake8-docstrings to minimum version of 1.5.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -116,8 +116,7 @@ commands = {[testenv:test-upstream-requirements-base]commands}
 basepython = python3
 deps =
     flake8
-    flake8-docstrings
-    pydocstyle<4.0.0
+    flake8-docstrings>=1.5.0
     # https://github.com/JBKahn/flake8-print/pull/30
     flake8-print>=3.1.0
     flake8-bugbear


### PR DESCRIPTION
*Issue #, if available:*
fixes #173 

*Description of changes:*
update flake8-docstrings to minimum version of 1.5.0 to address compatibility issues with pydocstyle 4.x

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

