### PR TITLE
master key provider keyring

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,10 @@ Modules
     aws_encryption_sdk.caches.base
     aws_encryption_sdk.caches.local
     aws_encryption_sdk.caches.null
+    aws_encryption_sdk.keyrings.base
+    aws_encryption_sdk.keyrings.master_key
+    aws_encryption_sdk.keyrings.multi
+    aws_encryption_sdk.keyrings.raw
     aws_encryption_sdk.key_providers.base
     aws_encryption_sdk.key_providers.kms
     aws_encryption_sdk.key_providers.raw

--- a/src/aws_encryption_sdk/exceptions.py
+++ b/src/aws_encryption_sdk/exceptions.py
@@ -87,6 +87,13 @@ class SignatureKeyError(AWSEncryptionSDKClientError):
     """
 
 
+class InvalidCryptographicMaterialsError(AWSEncryptionSDKClientError):
+    """Exception class for errors encountered when attempting to validate cryptographic materials.
+
+    .. versionadded:: 1.5.0
+    """
+
+
 class ActionNotAllowedError(AWSEncryptionSDKClientError):
     """Exception class for errors encountered when attempting to perform unallowed actions."""
 

--- a/src/aws_encryption_sdk/internal/formatting/serialize.py
+++ b/src/aws_encryption_sdk/internal/formatting/serialize.py
@@ -316,6 +316,6 @@ def serialize_wrapped_key(key_provider, wrapping_algorithm, wrapping_key_id, enc
         )
         key_ciphertext = encrypted_wrapped_key.ciphertext + encrypted_wrapped_key.tag
     return EncryptedDataKey(
-        key_provider=MasterKeyInfo(provider_id=key_provider.provider_id, key_info=key_info),
+        key_provider=MasterKeyInfo(provider_id=key_provider.provider_id, key_info=key_info, key_id=wrapping_key_id),
         encrypted_data_key=key_ciphertext,
     )

--- a/src/aws_encryption_sdk/key_providers/raw.py
+++ b/src/aws_encryption_sdk/key_providers/raw.py
@@ -23,7 +23,7 @@ import aws_encryption_sdk.internal.formatting.serialize
 from aws_encryption_sdk.identifiers import EncryptionType
 from aws_encryption_sdk.internal.crypto.wrapping_keys import WrappingKey
 from aws_encryption_sdk.key_providers.base import MasterKey, MasterKeyConfig, MasterKeyProvider, MasterKeyProviderConfig
-from aws_encryption_sdk.structures import DataKey, RawDataKey
+from aws_encryption_sdk.structures import DataKey, MasterKeyInfo, RawDataKey
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -182,7 +182,11 @@ class RawMasterKey(MasterKey):
         )
         # Raw key string to DataKey
         return DataKey(
-            key_provider=encrypted_data_key.key_provider,
+            key_provider=MasterKeyInfo(
+                provider_id=encrypted_data_key.key_provider.provider_id,
+                key_info=encrypted_data_key.key_provider.key_info,
+                key_id=self.key_id,
+            ),
             data_key=plaintext_data_key,
             encrypted_data_key=encrypted_data_key.encrypted_data_key,
         )

--- a/src/aws_encryption_sdk/keyrings/master_key.py
+++ b/src/aws_encryption_sdk/keyrings/master_key.py
@@ -1,0 +1,222 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Keyring for use with :class:`MasterKey`s and :class:`MasterKeyProvider`s."""
+import attr
+from attr.validators import instance_of
+
+from aws_encryption_sdk.exceptions import (
+    DecryptKeyError,
+    IncorrectMasterKeyError,
+    InvalidCryptographicMaterialsError,
+    MasterKeyProviderError,
+    UnknownIdentityError,
+)
+from aws_encryption_sdk.identifiers import EncryptionKeyType
+from aws_encryption_sdk.key_providers.base import MasterKey, MasterKeyProvider
+from aws_encryption_sdk.key_providers.kms import KMSMasterKey
+from aws_encryption_sdk.key_providers.raw import RawMasterKey
+from aws_encryption_sdk.keyrings.base import Keyring
+from aws_encryption_sdk.materials_managers import DecryptionMaterials, EncryptionMaterials
+from aws_encryption_sdk.structures import EncryptedDataKey, KeyringTrace, KeyringTraceFlag, RawDataKey
+
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Iterable, Set  # noqa pylint: disable=unused-import
+except ImportError:  # pragma: no cover
+    # We only actually need these imports when running the mypy checks
+    pass
+
+__all__ = ("MasterKeyProviderKeyring",)
+
+
+def _signs_encryption_context(master_key):
+    # type: (MasterKey) -> bool
+    if isinstance(master_key, KMSMasterKey):
+        return True
+
+    if isinstance(master_key, RawMasterKey):
+        if master_key.config.wrapping_key.wrapping_key_type is EncryptionKeyType.SYMMETRIC:
+            return True
+
+    return False
+
+
+def _generate_flags():
+    # type: () -> Set[KeyringTraceFlag]
+    """Build the keyring trace flags for a generate data key operation.
+
+    :return: Set of keyring trace flags
+    :rtype: set of :class:`KeyringTraceFlag`
+    """
+    return {KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY}
+
+
+def _encrypt_flags(master_key):
+    # type: (MasterKey) -> Set[KeyringTraceFlag]
+    """Build the keyring trace flags for an encrypt data key operation.
+
+    :param MasterKey master_key: Master key that encrypted the key
+    :return: Set of keyring trace flags
+    :rtype: set of :class:`KeyringTraceFlag`
+    """
+    flags = {KeyringTraceFlag.WRAPPING_KEY_ENCRYPTED_DATA_KEY}
+    if _signs_encryption_context(master_key):
+        flags.add(KeyringTraceFlag.WRAPPING_KEY_SIGNED_ENC_CTX)
+    return flags
+
+
+def _decrypt_flags(master_key):
+    # type: (MasterKey) -> Set[KeyringTraceFlag]
+    """Build the keyring trace flags for a decrypt data key operation.
+
+    :param MasterKey master_key: Master key that decrypted the key
+    :return: Set of keyring trace flags
+    :rtype: set of :class:`KeyringTraceFlag`
+    """
+    flags = {KeyringTraceFlag.WRAPPING_KEY_DECRYPTED_DATA_KEY}
+    if _signs_encryption_context(master_key):
+        flags.add(KeyringTraceFlag.WRAPPING_KEY_VERIFIED_ENC_CTX)
+    return flags
+
+
+@attr.s
+class MasterKeyProviderKeyring(Keyring):
+    """Keyring compatibility layer for use with master key providers.
+
+    .. versionadded:: 1.5.0
+
+    :param MasterKeyProvider master_key_provider: Master key provider to use
+    """
+
+    _master_key_provider = attr.ib(validator=instance_of(MasterKeyProvider))
+
+    def on_encrypt(self, encryption_materials):
+        # type: (EncryptionMaterials) -> EncryptionMaterials
+        """Generate a data key if not present and encrypt it using any available wrapping key.
+
+        :param encryption_materials: Encryption materials for the keyring to modify.
+        :type encryption_materials: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :returns: Optionally modified encryption materials.
+        :rtype: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :raises NotImplementedError: if method is not implemented
+        """
+        primary_master_key, master_keys = self._master_key_provider.master_keys_for_encryption(
+            encryption_context=encryption_materials.encryption_context, plaintext_rostream=None, plaintext_length=None,
+        )
+        if not master_keys:
+            raise MasterKeyProviderError("No Master Keys available from Master Key Provider")
+        if primary_master_key not in master_keys:
+            raise MasterKeyProviderError("Primary Master Key not in provided Master Keys")
+
+        if encryption_materials.data_encryption_key is not None:
+            # Because the default CMM used to require that the primary MKP was the generator,
+            #  this keyring cannot accept encryption materials that already have a data key.
+            raise InvalidCryptographicMaterialsError(
+                "Unable to use master keys with encryption materials that already contain a data key."
+                " You are probably trying to mix master key providers and keyrings."
+                " If you want to do that, the master key provider MUST be the generator."
+            )
+
+        data_encryption_key = primary_master_key.generate_data_key(
+            algorithm=encryption_materials.algorithm, encryption_context=encryption_materials.encryption_context,
+        )
+
+        encryption_materials.add_data_encryption_key(
+            data_encryption_key=RawDataKey(
+                data_key=data_encryption_key.data_key, key_provider=data_encryption_key.key_provider,
+            ),
+            keyring_trace=KeyringTrace(wrapping_key=primary_master_key.key_provider, flags=_generate_flags(),),
+        )
+        encryption_materials.add_encrypted_data_key(
+            encrypted_data_key=EncryptedDataKey(
+                key_provider=data_encryption_key.key_provider,
+                encrypted_data_key=data_encryption_key.encrypted_data_key,
+            ),
+            keyring_trace=KeyringTrace(
+                wrapping_key=primary_master_key.key_provider, flags=_encrypt_flags(primary_master_key),
+            ),
+        )
+
+        # Go through all of the other master keys and encrypt
+        for child in master_keys:
+            if child is primary_master_key:
+                # The additional master keys returned by MasterKeyProvider.master_keys_for_encryption
+                # can include the primary master key.
+                # We already have the encrypted data key from the primary, so skip it.
+                continue
+
+            encrypted_data_key = child.encrypt_data_key(
+                data_key=data_encryption_key,
+                algorithm=encryption_materials.algorithm,
+                encryption_context=encryption_materials.encryption_context,
+            )
+            encryption_materials.add_encrypted_data_key(
+                encrypted_data_key=EncryptedDataKey(
+                    key_provider=encrypted_data_key.key_provider,
+                    encrypted_data_key=encrypted_data_key.encrypted_data_key,
+                ),
+                keyring_trace=KeyringTrace(wrapping_key=child.key_provider, flags=_encrypt_flags(child)),
+            )
+
+        return encryption_materials
+
+    def on_decrypt(self, decryption_materials, encrypted_data_keys):
+        # type: (DecryptionMaterials, Iterable[EncryptedDataKey]) -> DecryptionMaterials
+        """Attempt to decrypt the encrypted data keys.
+
+        :param decryption_materials: Decryption materials for the keyring to modify.
+        :type decryption_materials: aws_encryption_sdk.materials_managers.DecryptionMaterials
+        :param encrypted_data_keys: List of encrypted data keys.
+        :type: Iterable of :class:`aws_encryption_sdk.structures.EncryptedDataKey`
+        :returns: Optionally modified decryption materials.
+        :rtype: aws_encryption_sdk.materials_managers.DecryptionMaterials
+        :raises NotImplementedError: if method is not implemented
+        """
+        # If the plaintext data key is set, just return.
+        if decryption_materials.data_encryption_key is not None:
+            return decryption_materials
+
+        # Use the master key provider to decrypt.
+        try:
+            decrypted_data_key = self._master_key_provider.decrypt_data_key_from_list(
+                encrypted_data_keys=encrypted_data_keys,
+                algorithm=decryption_materials.algorithm,
+                encryption_context=decryption_materials.encryption_context,
+            )
+        # MasterKeyProvider.decrypt_data_key throws DecryptKeyError
+        # but MasterKey.decrypt_data_key throws IncorrectMasterKeyError
+        except (IncorrectMasterKeyError, DecryptKeyError):
+            # Don't fail here for master key providers.
+            # The default CMM will fail if no keyrings can decrypt.
+            return decryption_materials
+
+        # Find the master key object that was used for decryption
+        #   This is important because we need the key ID for the trace,
+        #   not the provider info, which is what is in the returned data key.
+        try:
+            decrypting_master_key = list(self._master_key_provider.master_keys_for_data_key(decrypted_data_key))[0]
+        except IndexError:
+            raise UnknownIdentityError(
+                "Unable to locate master key for {}".format(repr(decrypted_data_key.key_provider))
+            )
+
+        # Add the plaintext data to the decryption materials, along with a trace.
+        decryption_materials.add_data_encryption_key(
+            data_encryption_key=RawDataKey(
+                key_provider=decrypted_data_key.key_provider, data_key=decrypted_data_key.data_key,
+            ),
+            keyring_trace=KeyringTrace(
+                wrapping_key=decrypting_master_key.key_provider, flags=_decrypt_flags(decrypting_master_key),
+            ),
+        )
+
+        return decryption_materials

--- a/src/aws_encryption_sdk/keyrings/multi.py
+++ b/src/aws_encryption_sdk/keyrings/multi.py
@@ -36,6 +36,8 @@ except ImportError:  # pragma: no cover
 class MultiKeyring(Keyring):
     """Public class for Multi Keyring.
 
+    .. versionadded:: 1.5.0
+
     :param generator: Generator keyring used to generate data encryption key (optional)
     :type generator: Keyring
     :param list children: List of keyrings used to encrypt the data encryption key (optional)

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -91,6 +91,8 @@ class RawAESKeyring(Keyring):
     """Generate an instance of Raw AES Keyring which encrypts using AES-GCM algorithm using wrapping key provided as a
     byte array
 
+    .. versionadded:: 1.5.0
+
     :param str key_namespace: String defining the keyring.
     :param bytes key_name: Key ID
     :param bytes wrapping_key: Encryption key with which to wrap plaintext data key.
@@ -239,6 +241,8 @@ class RawAESKeyring(Keyring):
 class RawRSAKeyring(Keyring):
     """Generate an instance of Raw RSA Keyring which performs asymmetric encryption and decryption using public
     and private keys provided
+
+    .. versionadded:: 1.5.0
 
     :param str key_namespace: String defining the keyring ID
     :param bytes key_name: Key ID

--- a/src/aws_encryption_sdk/materials_managers/__init__.py
+++ b/src/aws_encryption_sdk/materials_managers/__init__.py
@@ -133,7 +133,10 @@ class CryptographicMaterials(object):
             if flag not in keyring_trace.flags:
                 raise InvalidKeyringTraceError("Keyring flags do not match action.")
 
-        if keyring_trace.wrapping_key != data_encryption_key.key_provider:
+        if not (
+            keyring_trace.wrapping_key.provider_id == data_encryption_key.key_provider.provider_id
+            and keyring_trace.wrapping_key.key_id == data_encryption_key.key_provider.key_id
+        ):
             raise InvalidKeyringTraceError("Keyring trace does not match data key provider.")
 
         if len(data_encryption_key.data_key) != self.algorithm.kdf_input_len:
@@ -302,7 +305,10 @@ class EncryptionMaterials(CryptographicMaterials):
         if KeyringTraceFlag.WRAPPING_KEY_ENCRYPTED_DATA_KEY not in keyring_trace.flags:
             raise InvalidKeyringTraceError("Keyring flags do not match action.")
 
-        if keyring_trace.wrapping_key != encrypted_data_key.key_provider:
+        if not (
+            keyring_trace.wrapping_key.provider_id == encrypted_data_key.key_provider.provider_id
+            and keyring_trace.wrapping_key.key_id == encrypted_data_key.key_provider.key_id
+        ):
             raise InvalidKeyringTraceError("Keyring trace does not match data key encryptor.")
 
         self._encrypted_data_keys.append(encrypted_data_key)

--- a/src/aws_encryption_sdk/materials_managers/default.py
+++ b/src/aws_encryption_sdk/materials_managers/default.py
@@ -14,15 +14,17 @@
 import logging
 
 import attr
+from attr.validators import instance_of, optional
 
-from ..exceptions import MasterKeyProviderError, SerializationError
+from ..exceptions import InvalidCryptographicMaterialsError, SerializationError
 from ..internal.crypto.authentication import Signer, Verifier
 from ..internal.crypto.elliptic_curve import generate_ecc_signing_key
 from ..internal.defaults import ALGORITHM, ENCODED_SIGNER_KEY
 from ..internal.str_ops import to_str
-from ..internal.utils import prepare_data_keys
 from ..key_providers.base import MasterKeyProvider
-from . import DecryptionMaterials, EncryptionMaterials
+from ..keyrings.base import Keyring
+from ..keyrings.master_key import MasterKeyProviderKeyring
+from . import DecryptionMaterials, DecryptionMaterialsRequest, EncryptionMaterials, EncryptionMaterialsRequest
 from .base import CryptoMaterialsManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,12 +36,29 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
 
     .. versionadded:: 1.3.0
 
-    :param master_key_provider: Master key provider to use
-    :type master_key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
+
+    :param MasterKeyProvider master_key_provider: Master key provider to use
+        (either `keyring` or `master_key_provider` is required)
+    :param Keyring keyring: Keyring to use
+        (either `keyring` or `master_key_provider` is required)
     """
 
     algorithm = ALGORITHM
-    master_key_provider = attr.ib(validator=attr.validators.instance_of(MasterKeyProvider))
+    master_key_provider = attr.ib(default=None, validator=optional(instance_of(MasterKeyProvider)))
+    keyring = attr.ib(default=None, validator=optional(instance_of(Keyring)))
+
+    def __attrs_post_init__(self):
+        """Make sure that exactly one key provider is set and prep the keyring if needed."""
+        both = self.keyring is not None and self.master_key_provider is not None
+        neither = self.keyring is None and self.master_key_provider is None
+
+        if both or neither:
+            raise TypeError("Exactly one of 'master_key_provider' or 'keyring' must be provided.")
+
+        if self.keyring is None:
+            self.keyring = MasterKeyProviderKeyring(master_key_provider=self.master_key_provider)
 
     def _generate_signing_key_and_update_encryption_context(self, algorithm, encryption_context):
         """Generates a signing key based on the provided algorithm.
@@ -59,6 +78,7 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
         return signer.key_bytes()
 
     def get_encryption_materials(self, request):
+        # type: (EncryptionMaterialsRequest) -> EncryptionMaterials
         """Creates encryption materials using underlying master key provider.
 
         :param request: encryption materials request
@@ -74,32 +94,28 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
 
         signing_key = self._generate_signing_key_and_update_encryption_context(algorithm, encryption_context)
 
-        primary_master_key, master_keys = self.master_key_provider.master_keys_for_encryption(
-            encryption_context=encryption_context,
-            plaintext_rostream=request.plaintext_rostream,
-            plaintext_length=request.plaintext_length,
-        )
-        if not master_keys:
-            raise MasterKeyProviderError("No Master Keys available from Master Key Provider")
-        if primary_master_key not in master_keys:
-            raise MasterKeyProviderError("Primary Master Key not in provided Master Keys")
+        expected_encryption_context = encryption_context.copy()
 
-        data_encryption_key, encrypted_data_keys = prepare_data_keys(
-            primary_master_key=primary_master_key,
-            master_keys=master_keys,
-            algorithm=algorithm,
-            encryption_context=encryption_context,
+        encryption_materials = EncryptionMaterials(
+            algorithm=algorithm, encryption_context=encryption_context, signing_key=signing_key,
         )
 
-        _LOGGER.debug("Post-encrypt encryption context: %s", encryption_context)
+        final_materials = self.keyring.on_encrypt(encryption_materials=encryption_materials)
 
-        return EncryptionMaterials(
-            algorithm=algorithm,
-            data_encryption_key=data_encryption_key,
-            encrypted_data_keys=encrypted_data_keys,
-            encryption_context=encryption_context,
-            signing_key=signing_key,
+        if not final_materials.is_complete:
+            raise InvalidCryptographicMaterialsError("Encryption materials are incomplete!")
+
+        materials_are_valid = (
+            final_materials.algorithm is algorithm,
+            final_materials.encryption_context == expected_encryption_context,
+            final_materials.signing_key is signing_key,
         )
+        if not all(materials_are_valid):
+            raise InvalidCryptographicMaterialsError("Encryption materials do not match request!")
+
+        _LOGGER.debug("Post-encrypt encryption context: %s", final_materials.encryption_context)
+
+        return final_materials
 
     def _load_verification_key_from_encryption_context(self, algorithm, encryption_context):
         """Loads the verification key from the encryption context if used by algorithm suite.
@@ -125,6 +141,7 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
         return verifier.key_bytes()
 
     def decrypt_materials(self, request):
+        # type: (DecryptionMaterialsRequest) -> DecryptionMaterials
         """Obtains a plaintext data key from one or more encrypted data keys
         using underlying master key provider.
 
@@ -133,13 +150,28 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
         :returns: decryption materials
         :rtype: aws_encryption_sdk.materials_managers.DecryptionMaterials
         """
-        data_key = self.master_key_provider.decrypt_data_key_from_list(
-            encrypted_data_keys=request.encrypted_data_keys,
-            algorithm=request.algorithm,
-            encryption_context=request.encryption_context,
-        )
         verification_key = self._load_verification_key_from_encryption_context(
             algorithm=request.algorithm, encryption_context=request.encryption_context
         )
+        decryption_materials = DecryptionMaterials(
+            algorithm=request.algorithm,
+            encryption_context=request.encryption_context,
+            verification_key=verification_key,
+        )
 
-        return DecryptionMaterials(data_key=data_key, verification_key=verification_key)
+        final_materials = self.keyring.on_decrypt(
+            decryption_materials=decryption_materials, encrypted_data_keys=request.encrypted_data_keys
+        )
+
+        if not final_materials.is_complete:
+            raise InvalidCryptographicMaterialsError("Materials are incomplete!")
+
+        materials_are_valid = (
+            final_materials.algorithm is request.algorithm,
+            final_materials.encryption_context == request.encryption_context,
+            final_materials.verification_key is verification_key,
+        )
+        if not all(materials_are_valid):
+            raise InvalidCryptographicMaterialsError("Decryption materials do not match request!")
+
+        return final_materials

--- a/src/aws_encryption_sdk/structures.py
+++ b/src/aws_encryption_sdk/structures.py
@@ -15,7 +15,7 @@ import copy
 
 import attr
 import six
-from attr.validators import deep_iterable, deep_mapping, instance_of
+from attr.validators import deep_iterable, deep_mapping, instance_of, optional
 
 from aws_encryption_sdk.identifiers import Algorithm, ContentType, KeyringTraceFlag, ObjectType, SerializationVersion
 from aws_encryption_sdk.internal.str_ops import to_bytes, to_str
@@ -25,12 +25,32 @@ from aws_encryption_sdk.internal.str_ops import to_bytes, to_str
 class MasterKeyInfo(object):
     """Contains information necessary to identify a Master Key.
 
+    ``key_id`` is optional because ``key_id`` and ``key_info`` SHOULD
+    always be the same except in the case of the Raw AES Keyring/MasterKey.
+    This gives the option to specify a different ``key_id`` value if needed.
+
     :param str provider_id: MasterKey provider_id value
     :param bytes key_info: MasterKey key_info value
+    :param bytes key_id: MasterKey key_id value (optional)
     """
 
     provider_id = attr.ib(hash=True, validator=instance_of((six.string_types, bytes)), converter=to_str)
     key_info = attr.ib(hash=True, validator=instance_of((six.string_types, bytes)), converter=to_bytes)
+    _key_id = attr.ib(
+        hash=True,
+        eq=False,
+        default=None,
+        validator=optional(instance_of((six.string_types, bytes))),
+        converter=to_bytes,
+    )
+
+    @property
+    def key_id(self):
+        """Return the key ID if separately specified, or the key info if not."""
+        if self._key_id is None:
+            return self.key_info
+
+        return self._key_id
 
 
 @attr.s(hash=True)

--- a/test/integration/test_client.py
+++ b/test/integration/test_client.py
@@ -64,12 +64,13 @@ def test_encrypt_verify_user_agent_kms_master_key(caplog):
 
 def test_remove_bad_client():
     test = KMSMasterKeyProvider()
-    test.add_regional_client("us-fakey-12")
+    fake_region = "us-fakey-12"
+    test.add_regional_client(fake_region)
 
     with pytest.raises(BotoCoreError):
-        test._regional_clients["us-fakey-12"].list_keys()
+        test._regional_clients[fake_region].list_keys()
 
-    assert not test._regional_clients
+    assert fake_region not in test._regional_clients
 
 
 def test_regional_client_does_not_modify_botocore_session(caplog):

--- a/test/unit/keyrings/test_master_key.py
+++ b/test/unit/keyrings/test_master_key.py
@@ -1,0 +1,286 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Test suite for ``aws_encryption_sdk.keyrings.master_key``."""
+import itertools
+
+import pytest
+
+from aws_encryption_sdk.exceptions import (
+    InvalidCryptographicMaterialsError,
+    MasterKeyProviderError,
+    UnknownIdentityError,
+)
+from aws_encryption_sdk.identifiers import KeyringTraceFlag
+from aws_encryption_sdk.internal.defaults import ALGORITHM
+from aws_encryption_sdk.keyrings.master_key import MasterKeyProviderKeyring
+from aws_encryption_sdk.materials_managers import DecryptionMaterials, EncryptionMaterials
+from aws_encryption_sdk.structures import MasterKeyInfo, RawDataKey
+
+from ..unit_test_utils import (
+    DisjointMasterKeyProvider,
+    EmptyMasterKeyProvider,
+    EphemeralRawMasterKeyProvider,
+    FailingDecryptMasterKeyProvider,
+    UnknownDataKeyInfoMasterKeyProvider,
+    ephemeral_raw_aes_master_key,
+    ephemeral_raw_rsa_master_key,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
+
+def _encryption_contexts():
+    yield pytest.param({}, id="no encryption context")
+    yield pytest.param({"foo": "bar"}, id="some encryption context")
+
+
+@pytest.mark.parametrize("encryption_context", _encryption_contexts())
+def test_cycle(encryption_context):
+    mkp = ephemeral_raw_rsa_master_key()
+    keyring = MasterKeyProviderKeyring(master_key_provider=mkp)
+
+    encryption_materials = EncryptionMaterials(algorithm=ALGORITHM, encryption_context=encryption_context)
+
+    final_encryption_materials = keyring.on_encrypt(encryption_materials=encryption_materials)
+
+    decryption_materials = DecryptionMaterials(algorithm=ALGORITHM, encryption_context=encryption_context)
+
+    final_decryption_materials = keyring.on_decrypt(
+        decryption_materials=decryption_materials, encrypted_data_keys=final_encryption_materials.encrypted_data_keys
+    )
+
+    assert (
+        final_encryption_materials.data_encryption_key.data_key
+        == final_decryption_materials.data_encryption_key.data_key
+    )
+
+
+def _master_key_flags_on_encrypt():
+    single_raw_rsa_mkp = ephemeral_raw_rsa_master_key()
+    yield pytest.param(
+        single_raw_rsa_mkp,
+        single_raw_rsa_mkp.key_provider,
+        [KeyringTraceFlag.WRAPPING_KEY_ENCRYPTED_DATA_KEY, KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY],
+        id="single master key : raw RSA",
+    )
+
+    single_raw_aes_mkp = ephemeral_raw_aes_master_key()
+    yield pytest.param(
+        single_raw_aes_mkp,
+        single_raw_aes_mkp.key_provider,
+        [
+            KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY,
+            KeyringTraceFlag.WRAPPING_KEY_ENCRYPTED_DATA_KEY,
+            KeyringTraceFlag.WRAPPING_KEY_SIGNED_ENC_CTX,
+        ],
+        id="single master key : raw AES",
+    )
+
+    raw_provider = EphemeralRawMasterKeyProvider()
+    raw_provider.add_master_key(b"aes-256")
+    raw_provider.add_master_key(b"rsa-4096")
+    yield pytest.param(
+        raw_provider,
+        raw_provider.master_key(b"aes-256").key_provider,
+        [
+            KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY,
+            KeyringTraceFlag.WRAPPING_KEY_ENCRYPTED_DATA_KEY,
+            KeyringTraceFlag.WRAPPING_KEY_SIGNED_ENC_CTX,
+        ],
+        id="multiple master keys : raw AES generate and encrypt",
+    )
+    yield pytest.param(
+        raw_provider,
+        raw_provider.master_key(b"rsa-4096").key_provider,
+        [KeyringTraceFlag.WRAPPING_KEY_ENCRYPTED_DATA_KEY],
+        id="multiple master keys : raw RSA encrypt only",
+    )
+
+
+@pytest.mark.parametrize("master_key_provider, master_key_for_flags, expected_flags", _master_key_flags_on_encrypt())
+@pytest.mark.parametrize("encryption_context", _encryption_contexts())
+def test_keyring_flags_on_encrypt(master_key_provider, master_key_for_flags, expected_flags, encryption_context):
+    keyring = MasterKeyProviderKeyring(master_key_provider=master_key_provider)
+
+    encryption_materials = EncryptionMaterials(algorithm=ALGORITHM, encryption_context=encryption_context)
+
+    final_encryption_materials = keyring.on_encrypt(encryption_materials=encryption_materials)
+
+    actual_flags = list(
+        itertools.chain.from_iterable(
+            (
+                trace.flags
+                for trace in final_encryption_materials.keyring_trace
+                if trace.wrapping_key == master_key_for_flags
+            )
+        )
+    )
+    assert len(actual_flags) == len(expected_flags)
+    assert set(actual_flags) == set(expected_flags)
+
+
+def _master_key_flags_on_decrypt():
+    single_raw_rsa_mkp = ephemeral_raw_rsa_master_key()
+    yield pytest.param(
+        single_raw_rsa_mkp,
+        single_raw_rsa_mkp,
+        [KeyringTraceFlag.WRAPPING_KEY_DECRYPTED_DATA_KEY],
+        id="single master key : raw RSA",
+    )
+
+    single_raw_aes_mkp = ephemeral_raw_aes_master_key()
+    yield pytest.param(
+        single_raw_aes_mkp,
+        single_raw_aes_mkp,
+        [KeyringTraceFlag.WRAPPING_KEY_DECRYPTED_DATA_KEY, KeyringTraceFlag.WRAPPING_KEY_VERIFIED_ENC_CTX,],
+        id="single master key : raw AES",
+    )
+
+    raw_provider = EphemeralRawMasterKeyProvider()
+    raw_provider.add_master_key(b"aes-256")
+    raw_provider.add_master_key(b"rsa-4096")
+    yield pytest.param(
+        raw_provider,
+        raw_provider.master_key(b"aes-256"),
+        [KeyringTraceFlag.WRAPPING_KEY_DECRYPTED_DATA_KEY, KeyringTraceFlag.WRAPPING_KEY_VERIFIED_ENC_CTX,],
+        id="multiple master key encrypt : raw AES decrypt",
+    )
+    yield pytest.param(
+        raw_provider,
+        raw_provider.master_key(b"rsa-4096"),
+        [KeyringTraceFlag.WRAPPING_KEY_DECRYPTED_DATA_KEY],
+        id="multiple master key encrypt : raw RSA decrypt",
+    )
+
+
+@pytest.mark.parametrize(
+    "master_key_provider_for_encrypt, master_key_for_decrypt, expected_flags", _master_key_flags_on_decrypt()
+)
+@pytest.mark.parametrize("encryption_context", _encryption_contexts())
+def test_keyring_flags_on_decrypt(
+    master_key_provider_for_encrypt, master_key_for_decrypt, expected_flags, encryption_context
+):
+    keyring = MasterKeyProviderKeyring(master_key_provider=master_key_provider_for_encrypt)
+
+    encryption_materials = EncryptionMaterials(algorithm=ALGORITHM, encryption_context=encryption_context)
+
+    final_encryption_materials = keyring.on_encrypt(encryption_materials=encryption_materials)
+
+    decrypt_keyring = MasterKeyProviderKeyring(master_key_provider=master_key_for_decrypt)
+
+    decryption_materials = DecryptionMaterials(algorithm=ALGORITHM, encryption_context=encryption_context)
+
+    final_decryption_materials = decrypt_keyring.on_decrypt(
+        decryption_materials=decryption_materials, encrypted_data_keys=final_encryption_materials.encrypted_data_keys
+    )
+
+    actual_flags = list(
+        itertools.chain.from_iterable(
+            (
+                trace.flags
+                for trace in final_decryption_materials.keyring_trace
+                if trace.wrapping_key == master_key_for_decrypt.key_provider
+            )
+        )
+    )
+    assert len(actual_flags) == len(expected_flags)
+    assert set(actual_flags) == set(expected_flags)
+
+
+def test_on_encrypt_no_master_keys():
+    keyring = MasterKeyProviderKeyring(master_key_provider=EmptyMasterKeyProvider())
+
+    encryption_materials = EncryptionMaterials(algorithm=ALGORITHM, encryption_context={})
+
+    with pytest.raises(MasterKeyProviderError) as excinfo:
+        keyring.on_encrypt(encryption_materials=encryption_materials)
+
+    excinfo.match("No Master Keys available from Master Key Provider")
+
+
+def test_on_encrypt_primary_master_key_not_in_master_keys():
+    keyring = MasterKeyProviderKeyring(master_key_provider=DisjointMasterKeyProvider())
+
+    encryption_materials = EncryptionMaterials(algorithm=ALGORITHM, encryption_context={})
+
+    with pytest.raises(MasterKeyProviderError) as excinfo:
+        keyring.on_encrypt(encryption_materials=encryption_materials)
+
+    excinfo.match("Primary Master Key not in provided Master Keys")
+
+
+@pytest.mark.parametrize("encryption_context", _encryption_contexts())
+def test_on_encrypt_with_existing_data_key(encryption_context):
+    keyring = MasterKeyProviderKeyring(master_key_provider=ephemeral_raw_aes_master_key())
+
+    encryption_materials = EncryptionMaterials(
+        algorithm=ALGORITHM,
+        encryption_context=encryption_context,
+        data_encryption_key=RawDataKey(key_provider=MasterKeyInfo(provider_id="foo", key_info=b"bar"), data_key=b""),
+    )
+
+    with pytest.raises(InvalidCryptographicMaterialsError):
+        keyring.on_encrypt(encryption_materials=encryption_materials)
+
+
+def test_on_decrypt_with_existing_data_key():
+    keyring = MasterKeyProviderKeyring(master_key_provider=ephemeral_raw_aes_master_key())
+
+    decryption_materials = DecryptionMaterials(
+        algorithm=ALGORITHM,
+        encryption_context={},
+        data_encryption_key=RawDataKey(key_provider=MasterKeyInfo(provider_id="foo", key_info=b"bar"), data_key=b""),
+    )
+
+    final_decryption_materials = keyring.on_decrypt(decryption_materials=decryption_materials, encrypted_data_keys=[])
+
+    assert not final_decryption_materials.keyring_trace
+
+
+def test_on_decrypt_master_key_throws_error():
+    mkp = FailingDecryptMasterKeyProvider()
+    mkp.add_master_key(b"aes-256")
+    mkp.add_master_key(b"rsa-4096")
+    keyring = MasterKeyProviderKeyring(master_key_provider=mkp)
+
+    encryption_materials = EncryptionMaterials(algorithm=ALGORITHM, encryption_context={})
+
+    final_encryption_materials = keyring.on_encrypt(encryption_materials=encryption_materials)
+
+    decryption_materials = DecryptionMaterials(algorithm=ALGORITHM, encryption_context={})
+
+    final_decryption_materials = keyring.on_decrypt(
+        decryption_materials=decryption_materials, encrypted_data_keys=final_encryption_materials.encrypted_data_keys,
+    )
+    assert final_decryption_materials.data_encryption_key is None
+
+
+def test_on_decrypt_master_key_not_in_keyring_trace():
+    mkp = UnknownDataKeyInfoMasterKeyProvider()
+    mkp.add_master_key(b"aes-256")
+    mkp.add_master_key(b"rsa-4096")
+    keyring = MasterKeyProviderKeyring(master_key_provider=mkp)
+
+    encryption_materials = EncryptionMaterials(algorithm=ALGORITHM, encryption_context={})
+
+    final_encryption_materials = keyring.on_encrypt(encryption_materials=encryption_materials)
+
+    decryption_materials = DecryptionMaterials(algorithm=ALGORITHM, encryption_context={})
+
+    with pytest.raises(UnknownIdentityError) as excinfo:
+        keyring.on_decrypt(
+            decryption_materials=decryption_materials,
+            encrypted_data_keys=final_encryption_materials.encrypted_data_keys,
+        )
+
+    excinfo.match(r"Unable to locate master key for *")

--- a/test/unit/materials_managers/test_caching.py
+++ b/test/unit/materials_managers/test_caching.py
@@ -96,7 +96,7 @@ def test_mkp_to_default_cmm(mocker):
     )
 
     aws_encryption_sdk.materials_managers.caching.DefaultCryptoMaterialsManager.assert_called_once_with(
-        mock_mkp
+        master_key_provider=mock_mkp
     )  # noqa pylint: disable=line-too-long
     assert (
         test.backing_materials_manager


### PR DESCRIPTION
*Issue #, if available:* #146

*Description of changes:*

This adds `MasterKeyProviderKeyring` as an abstraction layer on top of master key providers (MKPs). This allows us to isolate MKP logic within this specific keyring so that everything upstream only ever needs to deal in keyrings and the keyring interface.

This gives us two benefits over leaving this logic in the default CMM:

1. It isolates MKP-specific logic. This makes the default CMM simpler and whenever we eventually remove MKPs, it will reduce the impact of that code change.
1. It lets us inject keyring trace entries for known MKPs.

`DefaultCryptoMaterialsManager` and `CachingCryptoMaterialsManager` also now accept a keyring in addition to a MKP (and a CMM in the case of the caching CMM).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

