### PR TITLE
feat: enable use of keyrings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,7 +67,10 @@ html_static_path = ["_static"]
 htmlhelp_basename = "%sdoc" % project
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"http://docs.python.org/": None}
+intersphinx_mapping = {
+    "python": ("http://docs.python.org/3/", None),
+    "cryptography": ("https://cryptography.io/en/latest/", None),
+}
 
 # autosummary
 autosummary_generate = True

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,9 @@ Modules
     aws_encryption_sdk.caches.base
     aws_encryption_sdk.caches.local
     aws_encryption_sdk.caches.null
+    aws_encryption_sdk.keyrings.base
+    aws_encryption_sdk.keyrings.multi
+    aws_encryption_sdk.keyrings.raw
     aws_encryption_sdk.key_providers.base
     aws_encryption_sdk.key_providers.kms
     aws_encryption_sdk.key_providers.raw

--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -33,6 +33,9 @@ def encrypt(**kwargs):
         When using this function, the entire ciphertext message is encrypted into memory before returning
         any data.  If streaming is desired, see :class:`aws_encryption_sdk.stream`.
 
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
+
     .. code:: python
 
         >>> import aws_encryption_sdk
@@ -86,6 +89,9 @@ def decrypt(**kwargs):
     .. note::
         When using this function, the entire ciphertext message is decrypted into memory before returning
         any data.  If streaming is desired, see :class:`aws_encryption_sdk.stream`.
+
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
 
     .. code:: python
 

--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """High level AWS Encryption SDK client functions."""
 # Below are imported for ease of use by implementors
 from aws_encryption_sdk.caches.local import LocalCryptoMaterialsCache  # noqa

--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -52,12 +52,14 @@ def encrypt(**kwargs):
     :type config: aws_encryption_sdk.streaming_client.EncryptorConfig
     :param source: Source data to encrypt or decrypt
     :type source: str, bytes, io.IOBase, or file
-    :param materials_manager: `CryptoMaterialsManager` from which to obtain cryptographic materials
-        (either `materials_manager` or `key_provider` required)
-    :type materials_manager: aws_encryption_sdk.materials_managers.base.CryptoMaterialsManager
-    :param key_provider: `MasterKeyProvider` from which to obtain data keys for encryption
-        (either `materials_manager` or `key_provider` required)
-    :type key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
+    :param CryptoMaterialsManager materials_manager:
+        Cryptographic materials manager to use for encryption
+        (either ``materials_manager``, ``keyring``, ``key_provider`` required)
+    :param Keyring keyring: Keyring to use for encryption
+        (either ``materials_manager``, ``keyring``, ``key_provider`` required)
+    :param MasterKeyProvider key_provider:
+        Master key provider to use for encryption
+        (either ``materials_manager``, ``keyring``, ``key_provider`` required)
     :param int source_length: Length of source data (optional)
 
         .. note::
@@ -109,12 +111,14 @@ def decrypt(**kwargs):
     :type config: aws_encryption_sdk.streaming_client.DecryptorConfig
     :param source: Source data to encrypt or decrypt
     :type source: str, bytes, io.IOBase, or file
-    :param materials_manager: `CryptoMaterialsManager` from which to obtain cryptographic materials
-        (either `materials_manager` or `key_provider` required)
-    :type materials_manager: aws_encryption_sdk.materials_managers.base.CryptoMaterialsManager
-    :param key_provider: `MasterKeyProvider` from which to obtain data keys for decryption
-        (either `materials_manager` or `key_provider` required)
-    :type key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
+    :param CryptoMaterialsManager materials_manager:
+        Cryptographic materials manager to use for encryption
+        (either ``materials_manager``, ``keyring``, ``key_provider`` required)
+    :param Keyring keyring: Keyring to use for encryption
+        (either ``materials_manager``, ``keyring``, ``key_provider`` required)
+    :param MasterKeyProvider key_provider:
+        Master key provider to use for encryption
+        (either ``materials_manager``, ``keyring``, ``key_provider`` required)
     :param int source_length: Length of source data (optional)
 
         .. note::

--- a/src/aws_encryption_sdk/exceptions.py
+++ b/src/aws_encryption_sdk/exceptions.py
@@ -87,6 +87,13 @@ class SignatureKeyError(AWSEncryptionSDKClientError):
     """
 
 
+class InvalidCryptographicMaterialsError(AWSEncryptionSDKClientError):
+    """Exception class for errors encountered when attempting to validate cryptographic materials.
+
+    .. versionadded:: 1.5.0
+    """
+
+
 class ActionNotAllowedError(AWSEncryptionSDKClientError):
     """Exception class for errors encountered when attempting to perform unallowed actions."""
 

--- a/src/aws_encryption_sdk/exceptions.py
+++ b/src/aws_encryption_sdk/exceptions.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Contains exception classes for AWS Encryption SDK."""
 
 

--- a/src/aws_encryption_sdk/keyrings/base.py
+++ b/src/aws_encryption_sdk/keyrings/base.py
@@ -23,6 +23,8 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
+__all__ = ("Keyring",)
+
 
 class Keyring(object):
     """Parent interface for Keyring classes.

--- a/src/aws_encryption_sdk/keyrings/base.py
+++ b/src/aws_encryption_sdk/keyrings/base.py
@@ -26,10 +26,9 @@ class Keyring(object):
         # type: (EncryptionMaterials) -> EncryptionMaterials
         """Generate a data key if not present and encrypt it using any available wrapping key.
 
-        :param encryption_materials: Encryption materials for the keyring to modify.
-        :type encryption_materials: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :param EncryptionMaterials encryption_materials: Encryption materials for keyring to modify.
         :returns: Optionally modified encryption materials.
-        :rtype: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :rtype: EncryptionMaterials
         :raises NotImplementedError: if method is not implemented
         """
         raise NotImplementedError("Keyring does not implement on_encrypt function")
@@ -38,12 +37,10 @@ class Keyring(object):
         # type: (DecryptionMaterials, Iterable[EncryptedDataKey]) -> DecryptionMaterials
         """Attempt to decrypt the encrypted data keys.
 
-        :param decryption_materials: Decryption materials for the keyring to modify.
-        :type decryption_materials: aws_encryption_sdk.materials_managers.DecryptionMaterials
-        :param encrypted_data_keys: List of encrypted data keys.
-        :type: Iterable of :class:`aws_encryption_sdk.structures.EncryptedDataKey`
+        :param DecryptionMaterials decryption_materials: Decryption materials for keyring to modify.
+        :param List[EncryptedDataKey] encrypted_data_keys: List of encrypted data keys.
         :returns: Optionally modified decryption materials.
-        :rtype: aws_encryption_sdk.materials_managers.DecryptionMaterials
+        :rtype: DecryptionMaterials
         :raises NotImplementedError: if method is not implemented
         """
         raise NotImplementedError("Keyring does not implement on_decrypt function")

--- a/src/aws_encryption_sdk/keyrings/base.py
+++ b/src/aws_encryption_sdk/keyrings/base.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Base class interface for Keyrings."""
 from aws_encryption_sdk.materials_managers import (  # only used for mypy; pylint: disable=unused-import
     DecryptionMaterials,

--- a/src/aws_encryption_sdk/keyrings/multi.py
+++ b/src/aws_encryption_sdk/keyrings/multi.py
@@ -31,6 +31,8 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
+__all__ = ("MultiKeyring",)
+
 
 @attr.s
 class MultiKeyring(Keyring):

--- a/src/aws_encryption_sdk/keyrings/multi.py
+++ b/src/aws_encryption_sdk/keyrings/multi.py
@@ -30,16 +30,15 @@ class MultiKeyring(Keyring):
 
     .. versionadded:: 1.5.0
 
-    :param generator: Generator keyring used to generate data encryption key (optional)
-    :type generator: Keyring
-    :param list children: List of keyrings used to encrypt the data encryption key (optional)
+    :param Keyring generator: Generator keyring used to generate data encryption key (optional)
+    :param List[Keyring] children: List of keyrings used to encrypt the data encryption key (optional)
     :raises EncryptKeyError: if encryption of data key fails for any reason
     """
 
+    generator = attr.ib(default=None, validator=optional(instance_of(Keyring)))
     children = attr.ib(
         default=attr.Factory(tuple), validator=optional(deep_iterable(member_validator=instance_of(Keyring)))
     )
-    generator = attr.ib(default=None, validator=optional(instance_of(Keyring)))
 
     def __attrs_post_init__(self):
         # type: () -> None
@@ -56,10 +55,9 @@ class MultiKeyring(Keyring):
         """Generate a data key using generator keyring
         and encrypt it using any available wrapping key in any child keyring.
 
-        :param encryption_materials: Encryption materials for keyring to modify.
-        :type encryption_materials: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :param EncryptionMaterials encryption_materials: Encryption materials for keyring to modify.
         :returns: Optionally modified encryption materials.
-        :rtype: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :rtype: EncryptionMaterials
         :raises EncryptKeyError: if unable to encrypt data key.
         """
         # Check if generator keyring is not provided and data key is not generated
@@ -88,12 +86,10 @@ class MultiKeyring(Keyring):
         # type: (DecryptionMaterials, Iterable[EncryptedDataKey]) -> DecryptionMaterials
         """Attempt to decrypt the encrypted data keys.
 
-        :param decryption_materials: Decryption materials for keyring to modify.
-        :type decryption_materials: aws_encryption_sdk.materials_managers.DecryptionMaterials
-        :param encrypted_data_keys: List of encrypted data keys.
-        :type: List of `aws_encryption_sdk.structures.EncryptedDataKey`
+        :param DecryptionMaterials decryption_materials: Decryption materials for keyring to modify.
+        :param List[EncryptedDataKey] encrypted_data_keys: List of encrypted data keys.
         :returns: Optionally modified decryption materials.
-        :rtype: aws_encryption_sdk.materials_managers.DecryptionMaterials
+        :rtype: DecryptionMaterials
         """
         # Call on_decrypt on all keyrings till decryption is successful
         for keyring in self._decryption_keyrings:

--- a/src/aws_encryption_sdk/keyrings/multi.py
+++ b/src/aws_encryption_sdk/keyrings/multi.py
@@ -38,6 +38,8 @@ __all__ = ("MultiKeyring",)
 class MultiKeyring(Keyring):
     """Public class for Multi Keyring.
 
+    .. versionadded:: 1.5.0
+
     :param generator: Generator keyring used to generate data encryption key (optional)
     :type generator: Keyring
     :param list children: List of keyrings used to encrypt the data encryption key (optional)

--- a/src/aws_encryption_sdk/keyrings/multi.py
+++ b/src/aws_encryption_sdk/keyrings/multi.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Resources required for Multi Keyrings."""
 import itertools
 

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -9,9 +9,7 @@ import six
 from attr.validators import instance_of, optional
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey  # noqa pylint: disable=unused-import
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey  # noqa pylint: disable=unused-import
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 
 from aws_encryption_sdk.exceptions import GenerateKeyError
 from aws_encryption_sdk.identifiers import EncryptionKeyType, KeyringTraceFlag, WrappingAlgorithm
@@ -223,21 +221,23 @@ class RawRSAKeyring(Keyring):
 
     :param str key_namespace: String defining the keyring ID
     :param bytes key_name: Key ID
-    :param RSAPrivateKey private_wrapping_key: Private encryption key with which to wrap plaintext data key (optional)
-    :param RSAPublicKey public_wrapping_key: Public encryption key with which to wrap plaintext data key (optional)
+    :param cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey private_wrapping_key:
+        Private encryption key with which to wrap plaintext data key (optional)
+    :param cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey public_wrapping_key:
+        Public encryption key with which to wrap plaintext data key (optional)
     :param WrappingAlgorithm wrapping_algorithm: Wrapping Algorithm with which to wrap plaintext data key
     :param MasterKeyInfo key_provider: Complete information about the key in the keyring
 
     .. note::
 
-       At least one of public wrapping key or private wrapping key must be provided.
+        At least one of public wrapping key or private wrapping key must be provided.
     """
 
     key_namespace = attr.ib(validator=instance_of(six.string_types))
     key_name = attr.ib(validator=instance_of(six.binary_type))
     _wrapping_algorithm = attr.ib(repr=False, validator=instance_of(WrappingAlgorithm))
-    _private_wrapping_key = attr.ib(default=None, repr=False, validator=optional(instance_of(rsa.RSAPrivateKey)))
-    _public_wrapping_key = attr.ib(default=None, repr=False, validator=optional(instance_of(rsa.RSAPublicKey)))
+    _private_wrapping_key = attr.ib(default=None, repr=False, validator=optional(instance_of(RSAPrivateKey)))
+    _public_wrapping_key = attr.ib(default=None, repr=False, validator=optional(instance_of(RSAPublicKey)))
 
     def __attrs_post_init__(self):
         # type: () -> None

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -10,7 +10,8 @@ from attr.validators import instance_of, optional
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey  # noqa pylint: disable=unused-import
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey  # noqa pylint: disable=unused-import
 
 from aws_encryption_sdk.exceptions import GenerateKeyError
 from aws_encryption_sdk.identifiers import EncryptionKeyType, KeyringTraceFlag, WrappingAlgorithm
@@ -19,14 +20,14 @@ from aws_encryption_sdk.internal.formatting.deserialize import deserialize_wrapp
 from aws_encryption_sdk.internal.formatting.serialize import serialize_raw_master_key_prefix, serialize_wrapped_key
 from aws_encryption_sdk.key_providers.raw import RawMasterKey
 from aws_encryption_sdk.keyrings.base import Keyring
-from aws_encryption_sdk.structures import (  # pylint: disable=unused-import
+from aws_encryption_sdk.structures import (
     EncryptedDataKey,
     KeyringTrace,
     MasterKeyInfo,
     RawDataKey,
 )
 
-from aws_encryption_sdk.materials_managers import (  # only used for mypy; pylint: disable=unused-import
+from aws_encryption_sdk.materials_managers import (
     DecryptionMaterials,
     EncryptionMaterials,
 )

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -20,17 +20,8 @@ from aws_encryption_sdk.internal.formatting.deserialize import deserialize_wrapp
 from aws_encryption_sdk.internal.formatting.serialize import serialize_raw_master_key_prefix, serialize_wrapped_key
 from aws_encryption_sdk.key_providers.raw import RawMasterKey
 from aws_encryption_sdk.keyrings.base import Keyring
-from aws_encryption_sdk.structures import (
-    EncryptedDataKey,
-    KeyringTrace,
-    MasterKeyInfo,
-    RawDataKey,
-)
-
-from aws_encryption_sdk.materials_managers import (
-    DecryptionMaterials,
-    EncryptionMaterials,
-)
+from aws_encryption_sdk.materials_managers import DecryptionMaterials, EncryptionMaterials
+from aws_encryption_sdk.structures import EncryptedDataKey, KeyringTrace, MasterKeyInfo, RawDataKey
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Iterable  # noqa pylint: disable=unused-import

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -92,6 +92,8 @@ class RawAESKeyring(Keyring):
     """Generate an instance of Raw AES Keyring which encrypts using AES-GCM algorithm using wrapping key provided as a
     byte array
 
+    .. versionadded:: 1.5.0
+
     :param str key_namespace: String defining the keyring.
     :param bytes key_name: Key ID
     :param bytes wrapping_key: Encryption key with which to wrap plaintext data key.
@@ -240,6 +242,8 @@ class RawAESKeyring(Keyring):
 class RawRSAKeyring(Keyring):
     """Generate an instance of Raw RSA Keyring which performs asymmetric encryption and decryption using public
     and private keys provided
+
+    .. versionadded:: 1.5.0
 
     :param str key_namespace: String defining the keyring ID
     :param bytes key_name: Key ID

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Resources required for Raw Keyrings."""
 import logging
 import os

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -46,6 +46,7 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
+__all__ = ("RawAESKeyring", "RawRSAKeyring")
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -10,6 +10,7 @@ from attr.validators import instance_of, optional
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 
 from aws_encryption_sdk.exceptions import GenerateKeyError
 from aws_encryption_sdk.identifiers import EncryptionKeyType, KeyringTraceFlag, WrappingAlgorithm
@@ -47,10 +48,8 @@ def _generate_data_key(
     # type: (...) -> bytes
     """Generates plaintext data key for the keyring.
 
-    :param encryption_materials: Encryption materials for the keyring to modify.
-    :type encryption_materials: aws_encryption_sdk.materials_managers.EncryptionMaterials
-    :param key_provider: Information about the key in the keyring.
-    :type key_provider: MasterKeyInfo
+    :param EncryptionMaterials encryption_materials: Encryption materials for the keyring to modify.
+    :param MasterKeyInfo key_provider: Information about the key in the keyring.
     :return bytes: Plaintext data key
     """
     # Check if encryption materials contain data encryption key
@@ -87,8 +86,7 @@ class RawAESKeyring(Keyring):
     :param str key_namespace: String defining the keyring.
     :param bytes key_name: Key ID
     :param bytes wrapping_key: Encryption key with which to wrap plaintext data key.
-    :param wrapping_algorithm: Wrapping Algorithm with which to wrap plaintext data key.
-    :type wrapping_algorithm: WrappingAlgorithm
+    :param WrappingAlgorithm wrapping_algorithm: Wrapping Algorithm with which to wrap plaintext data key.
 
     .. note::
     Only one wrapping key can be specified in a Raw AES Keyring
@@ -121,8 +119,7 @@ class RawAESKeyring(Keyring):
 
         :param str key_namespace: String defining the keyring.
         :param bytes key_name: Key ID
-        :param wrapping_key: Encryption key with which to wrap plaintext data key.
-        :type wrapping_key: WrappingKey
+        :param WrappingKey wrapping_key: Encryption key with which to wrap plaintext data key.
         :return: Serialized key_info prefix
         :rtype: bytes
         """
@@ -135,10 +132,9 @@ class RawAESKeyring(Keyring):
         # type: (EncryptionMaterials) -> EncryptionMaterials
         """Generate a data key if not present and encrypt it using any available wrapping key
 
-        :param encryption_materials: Encryption materials for the keyring to modify
-        :type encryption_materials: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :param EncryptionMaterials encryption_materials: Encryption materials for the keyring to modify
         :returns: Optionally modified encryption materials
-        :rtype: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :rtype: EncryptionMaterials
         """
         if encryption_materials.data_encryption_key is None:
             _generate_data_key(encryption_materials=encryption_materials, key_provider=self._key_provider)
@@ -175,12 +171,10 @@ class RawAESKeyring(Keyring):
         # type: (DecryptionMaterials, Iterable[EncryptedDataKey]) -> DecryptionMaterials
         """Attempt to decrypt the encrypted data keys.
 
-        :param decryption_materials: Decryption materials for the keyring to modify
-        :type decryption_materials: aws_encryption_sdk.materials_managers.DecryptionMaterials
-        :param encrypted_data_keys: List of encrypted data keys
-        :type: List of `aws_encryption_sdk.structures.EncryptedDataKey`
+        :param DecryptionMaterials decryption_materials: Decryption materials for the keyring to modify
+        :param List[EncryptedDataKey] encrypted_data_keys: List of encrypted data keys
         :returns: Optionally modified decryption materials
-        :rtype: aws_encryption_sdk.materials_managers.DecryptionMaterials
+        :rtype: DecryptionMaterials
         """
         if decryption_materials.data_encryption_key is not None:
             return decryption_materials
@@ -237,17 +231,14 @@ class RawRSAKeyring(Keyring):
 
     :param str key_namespace: String defining the keyring ID
     :param bytes key_name: Key ID
-    :param private_wrapping_key: Private encryption key with which to wrap plaintext data key (optional)
-    :type private_wrapping_key: RSAPrivateKey
-    :param public_wrapping_key: Public encryption key with which to wrap plaintext data key (optional)
-    :type public_wrapping_key: RSAPublicKey
-    :param wrapping_algorithm: Wrapping Algorithm with which to wrap plaintext data key
-    :type wrapping_algorithm: WrappingAlgorithm
-    :param key_provider: Complete information about the key in the keyring
-    :type key_provider: MasterKeyInfo
+    :param RSAPrivateKey private_wrapping_key: Private encryption key with which to wrap plaintext data key (optional)
+    :param RSAPublicKey public_wrapping_key: Public encryption key with which to wrap plaintext data key (optional)
+    :param WrappingAlgorithm wrapping_algorithm: Wrapping Algorithm with which to wrap plaintext data key
+    :param MasterKeyInfo key_provider: Complete information about the key in the keyring
 
     .. note::
-    At least one of public wrapping key or private wrapping key must be provided.
+
+       At least one of public wrapping key or private wrapping key must be provided.
     """
 
     key_namespace = attr.ib(validator=instance_of(six.string_types))
@@ -282,12 +273,11 @@ class RawRSAKeyring(Keyring):
 
         :param str key_namespace: String defining the keyring ID
         :param bytes key_name: Key ID
-        :param wrapping_algorithm: Wrapping Algorithm with which to wrap plaintext data key
-        :type wrapping_algorithm: WrappingAlgorithm
+        :param WrappingAlgorithm wrapping_algorithm: Wrapping Algorithm with which to wrap plaintext data key
         :param bytes public_encoded_key: PEM encoded public key (optional)
         :param bytes private_encoded_key: PEM encoded private key (optional)
         :param bytes password: Password to load private key (optional)
-        :return: Calls RawRSAKeyring class with required parameters
+        :return: :class:`RawRSAKeyring` constructed using required parameters
         """
         loaded_private_wrapping_key = loaded_public_wrapping_key = None
         if private_encoded_key is not None:
@@ -321,12 +311,11 @@ class RawRSAKeyring(Keyring):
 
         :param str key_namespace: String defining the keyring ID
         :param bytes key_name: Key ID
-        :param wrapping_algorithm: Wrapping Algorithm with which to wrap plaintext data key
-        :type wrapping_algorithm: WrappingAlgorithm
+        :param WrappingAlgorithm wrapping_algorithm: Wrapping Algorithm with which to wrap plaintext data key
         :param bytes public_encoded_key: DER encoded public key (optional)
         :param bytes private_encoded_key: DER encoded private key (optional)
-        :param password: Password to load private key (optional)
-        :return: Calls RawRSAKeyring class with required parameters
+        :param bytes password: Password to load private key (optional)
+        :return: :class:`RawRSAKeyring` constructed using required parameters
         """
         loaded_private_wrapping_key = loaded_public_wrapping_key = None
         if private_encoded_key is not None:
@@ -348,12 +337,12 @@ class RawRSAKeyring(Keyring):
 
     def on_encrypt(self, encryption_materials):
         # type: (EncryptionMaterials) -> EncryptionMaterials
-        """Generate a data key if not present and encrypt it using any available wrapping key.
+        """Generate a data key using generator keyring
+        and encrypt it using any available wrapping key in any child keyring.
 
-        :param encryption_materials: Encryption materials for the keyring to modify.
-        :type encryption_materials: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :param EncryptionMaterials encryption_materials: Encryption materials for keyring to modify.
         :returns: Optionally modified encryption materials.
-        :rtype: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :rtype: EncryptionMaterials
         """
         if encryption_materials.data_encryption_key is None:
             _generate_data_key(encryption_materials=encryption_materials, key_provider=self._key_provider)
@@ -398,12 +387,11 @@ class RawRSAKeyring(Keyring):
         # type: (DecryptionMaterials, Iterable[EncryptedDataKey]) -> DecryptionMaterials
         """Attempt to decrypt the encrypted data keys.
 
-        :param decryption_materials: Decryption materials for the keyring to modify.
-        :type decryption_materials: aws_encryption_sdk.materials_managers.DecryptionMaterials
+        :param DecryptionMaterials decryption_materials: Decryption materials for keyring to modify.
         :param encrypted_data_keys: List of encrypted data keys.
-        :type: List of `aws_encryption_sdk.structures.EncryptedDataKey`
+        :type: List[EncryptedDataKey]
         :returns: Optionally modified decryption materials.
-        :rtype: aws_encryption_sdk.materials_managers.DecryptionMaterials
+        :rtype: DecryptionMaterials
         """
         if self._private_wrapping_key is None:
             return decryption_materials

--- a/src/aws_encryption_sdk/materials_managers/__init__.py
+++ b/src/aws_encryption_sdk/materials_managers/__init__.py
@@ -248,7 +248,7 @@ class EncryptionMaterials(CryptographicMaterials):
     @property
     def is_complete(self):
         # type: () -> bool
-        """Determine whether these materials are sufficiently complete for use as decryption materials.
+        """Determine whether these materials are sufficiently complete for use as encryption materials.
 
         :rtype: bool
         """

--- a/src/aws_encryption_sdk/materials_managers/caching.py
+++ b/src/aws_encryption_sdk/materials_managers/caching.py
@@ -56,8 +56,7 @@ class CachingCryptoMaterialsManager(CryptoMaterialsManager):
         value.  If no partition name is provided, a random UUID will be used.
 
     .. note::
-        Either ``backing_materials_manager``, ``keyring``, or ``master_key_provider`` must be provided.
-        ``backing_materials_manager`` will always be used if present.
+        Exactly one of ``backing_materials_manager``, ``keyring``, or ``master_key_provider`` must be provided.
 
     :param CryptoMaterialsCache cache: Crypto cache to use with material manager
     :param CryptoMaterialsManager backing_materials_manager:
@@ -107,7 +106,7 @@ class CachingCryptoMaterialsManager(CryptoMaterialsManager):
         provided_count = len([is_set for is_set in options_provided if is_set])
 
         if provided_count != 1:
-            raise TypeError("Exactly one of 'materials_manager', 'keyring', or 'key_provider' must be provided")
+            raise TypeError("Exactly one of 'backing_materials_manager', 'keyring', or 'key_provider' must be provided")
 
         if self.backing_materials_manager is None:
             if self.master_key_provider is not None:

--- a/src/aws_encryption_sdk/materials_managers/caching.py
+++ b/src/aws_encryption_sdk/materials_managers/caching.py
@@ -44,6 +44,9 @@ class CachingCryptoMaterialsManager(CryptoMaterialsManager):
 
     .. versionadded:: 1.3.0
 
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
+
     >>> import aws_encryption_sdk
     >>> kms_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(key_ids=[
     ...     'arn:aws:kms:us-east-1:2222222222222:key/22222222-2222-2222-2222-222222222222',

--- a/src/aws_encryption_sdk/materials_managers/caching.py
+++ b/src/aws_encryption_sdk/materials_managers/caching.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Caching crypto material manager."""
 import logging
 import uuid

--- a/src/aws_encryption_sdk/materials_managers/caching.py
+++ b/src/aws_encryption_sdk/materials_managers/caching.py
@@ -16,17 +16,20 @@ import uuid
 
 import attr
 import six
+from attr.validators import instance_of, optional
 
-from ..caches import (
+from aws_encryption_sdk.caches import (
     CryptoMaterialsCacheEntryHints,
     build_decryption_materials_cache_key,
     build_encryption_materials_cache_key,
 )
-from ..caches.base import CryptoMaterialsCache
-from ..exceptions import CacheKeyError
-from ..internal.defaults import MAX_BYTES_PER_KEY, MAX_MESSAGES_PER_KEY
-from ..internal.str_ops import to_bytes
-from ..key_providers.base import MasterKeyProvider
+from aws_encryption_sdk.caches.base import CryptoMaterialsCache
+from aws_encryption_sdk.exceptions import CacheKeyError
+from aws_encryption_sdk.internal.defaults import MAX_BYTES_PER_KEY, MAX_MESSAGES_PER_KEY
+from aws_encryption_sdk.internal.str_ops import to_bytes
+from aws_encryption_sdk.key_providers.base import MasterKeyProvider
+from aws_encryption_sdk.keyrings.base import Keyring
+
 from . import EncryptionMaterialsRequest
 from .base import CryptoMaterialsManager
 from .default import DefaultCryptoMaterialsManager
@@ -59,17 +62,17 @@ class CachingCryptoMaterialsManager(CryptoMaterialsManager):
         value.  If no partition name is provided, a random UUID will be used.
 
     .. note::
-        Either `backing_materials_manager` or `master_key_provider` must be provided.
-        `backing_materials_manager` will always be used if present.
+        Either ``backing_materials_manager``, ``keyring``, or ``master_key_provider`` must be provided.
+        ``backing_materials_manager`` will always be used if present.
 
-    :param cache: Crypto cache to use with material manager
-    :type cache: aws_encryption_sdk.caches.base.CryptoMaterialsCache
-    :param backing_materials_manager: Crypto material manager to back this caching material manager
-        (either `backing_materials_manager` or `master_key_provider` required)
-    :type backing_materials_manager: aws_encryption_sdk.materials_managers.base.CryptoMaterialsManager
-    :param master_key_provider: Master key provider to use (either `backing_materials_manager` or
-        `master_key_provider` required)
-    :type master_key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
+    :param CryptoMaterialsCache cache: Crypto cache to use with material manager
+    :param CryptoMaterialsManager backing_materials_manager:
+       Crypto material manager to back this caching material manager
+       (either ``backing_materials_manager``, ``keyring``, or ``master_key_provider`` required)
+    :param MasterKeyProvider master_key_provider: Master key provider to use
+       (either ``backing_materials_manager``, ``keyring``, or ``master_key_provider`` required)
+    :param Keyring keyring: Keyring to use
+       (either ``backing_materials_manager``, ``keyring``, or ``master_key_provider`` required)
     :param float max_age: Maximum time in seconds that a cache entry may be kept in the cache
     :param int max_messages_encrypted: Maximum number of messages that may be encrypted under
         a cache entry (optional)
@@ -78,21 +81,14 @@ class CachingCryptoMaterialsManager(CryptoMaterialsManager):
     :param bytes partition_name: Partition name to use for this instance (optional)
     """
 
-    cache = attr.ib(validator=attr.validators.instance_of(CryptoMaterialsCache))
-    max_age = attr.ib(validator=attr.validators.instance_of(float))
-    max_messages_encrypted = attr.ib(
-        default=MAX_MESSAGES_PER_KEY, validator=attr.validators.instance_of(six.integer_types)
-    )
-    max_bytes_encrypted = attr.ib(default=MAX_BYTES_PER_KEY, validator=attr.validators.instance_of(six.integer_types))
-    partition_name = attr.ib(
-        default=None, converter=to_bytes, validator=attr.validators.optional(attr.validators.instance_of(bytes))
-    )
-    master_key_provider = attr.ib(
-        default=None, validator=attr.validators.optional(attr.validators.instance_of(MasterKeyProvider))
-    )
-    backing_materials_manager = attr.ib(
-        default=None, validator=attr.validators.optional(attr.validators.instance_of(CryptoMaterialsManager))
-    )
+    cache = attr.ib(validator=instance_of(CryptoMaterialsCache))
+    max_age = attr.ib(validator=instance_of(float))
+    max_messages_encrypted = attr.ib(default=MAX_MESSAGES_PER_KEY, validator=instance_of(six.integer_types))
+    max_bytes_encrypted = attr.ib(default=MAX_BYTES_PER_KEY, validator=instance_of(six.integer_types))
+    partition_name = attr.ib(default=None, converter=to_bytes, validator=optional(instance_of(bytes)))
+    master_key_provider = attr.ib(default=None, validator=optional(instance_of(MasterKeyProvider)))
+    backing_materials_manager = attr.ib(default=None, validator=optional(instance_of(CryptoMaterialsManager)))
+    keyring = attr.ib(default=None, validator=optional(instance_of(Keyring)))
 
     def __attrs_post_init__(self):
         """Applies post-processing which cannot be handled by attrs."""
@@ -111,10 +107,21 @@ class CachingCryptoMaterialsManager(CryptoMaterialsManager):
         if self.max_age <= 0.0:
             raise ValueError("max_age cannot be less than or equal to 0")
 
+        options_provided = [
+            option is not None for option in (self.backing_materials_manager, self.keyring, self.master_key_provider)
+        ]
+        provided_count = len([is_set for is_set in options_provided if is_set])
+
+        if provided_count != 1:
+            raise TypeError("Exactly one of 'materials_manager', 'keyring', or 'key_provider' must be provided")
+
         if self.backing_materials_manager is None:
-            if self.master_key_provider is None:
-                raise TypeError("Either backing_materials_manager or master_key_provider must be defined")
-            self.backing_materials_manager = DefaultCryptoMaterialsManager(self.master_key_provider)
+            if self.master_key_provider is not None:
+                self.backing_materials_manager = DefaultCryptoMaterialsManager(
+                    master_key_provider=self.master_key_provider
+                )
+            else:
+                self.backing_materials_manager = DefaultCryptoMaterialsManager(keyring=self.keyring)
 
         if self.partition_name is None:
             self.partition_name = to_bytes(str(uuid.uuid4()))

--- a/src/aws_encryption_sdk/materials_managers/caching.py
+++ b/src/aws_encryption_sdk/materials_managers/caching.py
@@ -39,6 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @attr.s(hash=False)
 class CachingCryptoMaterialsManager(CryptoMaterialsManager):
+    # pylint: disable=too-many-instance-attributes
     """Crypto material manager which caches results from an underlying material manager.
 
     .. versionadded:: 1.3.0

--- a/src/aws_encryption_sdk/materials_managers/default.py
+++ b/src/aws_encryption_sdk/materials_managers/default.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Default crypto material manager class."""
 import logging
 

--- a/src/aws_encryption_sdk/materials_managers/default.py
+++ b/src/aws_encryption_sdk/materials_managers/default.py
@@ -14,16 +14,18 @@
 import logging
 
 import attr
+from attr.validators import instance_of, optional
 
-from ..exceptions import MasterKeyProviderError, SerializationError
-from ..internal.crypto.authentication import Signer, Verifier
-from ..internal.crypto.elliptic_curve import generate_ecc_signing_key
-from ..internal.defaults import ALGORITHM, ENCODED_SIGNER_KEY
-from ..internal.str_ops import to_str
-from ..internal.utils import prepare_data_keys
-from ..key_providers.base import MasterKeyProvider
-from . import DecryptionMaterials, EncryptionMaterials
-from .base import CryptoMaterialsManager
+from aws_encryption_sdk.exceptions import InvalidCryptographicMaterialsError, MasterKeyProviderError, SerializationError
+from aws_encryption_sdk.internal.crypto.authentication import Signer, Verifier
+from aws_encryption_sdk.internal.crypto.elliptic_curve import generate_ecc_signing_key
+from aws_encryption_sdk.internal.defaults import ALGORITHM, ENCODED_SIGNER_KEY
+from aws_encryption_sdk.internal.str_ops import to_str
+from aws_encryption_sdk.internal.utils import prepare_data_keys
+from aws_encryption_sdk.key_providers.base import MasterKeyProvider
+from aws_encryption_sdk.keyrings.base import Keyring
+from aws_encryption_sdk.materials_managers import DecryptionMaterials, EncryptionMaterials
+from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,12 +36,25 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
 
     .. versionadded:: 1.3.0
 
-    :param master_key_provider: Master key provider to use
-    :type master_key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
+
+    :param MasterKeyProvider master_key_provider: Master key provider to use
+       (either `keyring` or `master_key_provider` is required)
+    :param Keyring keyring: Keyring to use
+       (either `keyring` or `master_key_provider` is required)
     """
 
     algorithm = ALGORITHM
-    master_key_provider = attr.ib(validator=attr.validators.instance_of(MasterKeyProvider))
+    master_key_provider = attr.ib(default=None, validator=optional(instance_of(MasterKeyProvider)))
+    keyring = attr.ib(default=None, validator=optional(instance_of(Keyring)))
+
+    def __attrs_post_init__(self):
+        both = self.master_key_provider is not None and self.keyring is not None
+        neither = self.master_key_provider is None and self.keyring is None
+
+        if both or neither:
+            raise TypeError("Exactly one of 'keyring' or 'master_key_provider' must be supplied.")
 
     def _generate_signing_key_and_update_encryption_context(self, algorithm, encryption_context):
         """Generates a signing key based on the provided algorithm.
@@ -58,7 +73,7 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
         encryption_context[ENCODED_SIGNER_KEY] = to_str(signer.encoded_public_key())
         return signer.key_bytes()
 
-    def get_encryption_materials(self, request):
+    def _get_encryption_materials_using_master_key_provider(self, request):
         """Creates encryption materials using underlying master key provider.
 
         :param request: encryption materials request
@@ -101,6 +116,64 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
             signing_key=signing_key,
         )
 
+    def _get_encryption_materials_using_keyring(self, request):
+        """Creates encryption materials using underlying keyring.
+
+        :param request: encryption materials request
+        :type request: aws_encryption_sdk.materials_managers.EncryptionMaterialsRequest
+        :returns: encryption materials
+        :rtype: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :raises InvalidCryptographicMaterialsError: if keyring cannot complete encryption materials
+        :raises InvalidCryptographicMaterialsError:
+           if encryption materials received from keyring do not match request
+        """
+        algorithm = request.algorithm if request.algorithm is not None else self.algorithm
+        encryption_context = request.encryption_context.copy()
+
+        signing_key = self._generate_signing_key_and_update_encryption_context(algorithm, encryption_context)
+
+        expected_encryption_context = encryption_context.copy()
+
+        encryption_materials = EncryptionMaterials(
+            algorithm=algorithm, encryption_context=encryption_context, signing_key=signing_key,
+        )
+
+        final_materials = self.keyring.on_encrypt(encryption_materials=encryption_materials)
+
+        if not final_materials.is_complete:
+            raise InvalidCryptographicMaterialsError("Encryption materials are incomplete!")
+
+        materials_are_valid = (
+            final_materials.algorithm is algorithm,
+            final_materials.encryption_context == expected_encryption_context,
+            final_materials.signing_key is signing_key,
+        )
+        if not all(materials_are_valid):
+            raise InvalidCryptographicMaterialsError("Encryption materials do not match request!")
+
+        _LOGGER.debug("Post-encrypt encryption context: %s", encryption_context)
+
+        return final_materials
+
+    def get_encryption_materials(self, request):
+        """Creates encryption materials using underlying master key provider.
+
+        :param request: encryption materials request
+        :type request: aws_encryption_sdk.materials_managers.EncryptionMaterialsRequest
+        :returns: encryption materials
+        :rtype: aws_encryption_sdk.materials_managers.EncryptionMaterials
+        :raises InvalidCryptographicMaterialsError: if keyring cannot complete encryption materials
+        :raises InvalidCryptographicMaterialsError:
+           if encryption materials received from keyring do not match request
+        :raises MasterKeyProviderError: if no master keys are available from the underlying master key provider
+        :raises MasterKeyProviderError: if the primary master key provided by the underlying master key provider
+            is not included in the full set of master keys provided by that provider
+        """
+        if self.master_key_provider is not None:
+            return self._get_encryption_materials_using_master_key_provider(request)
+
+        return self._get_encryption_materials_using_keyring(request)
+
     def _load_verification_key_from_encryption_context(self, algorithm, encryption_context):
         """Loads the verification key from the encryption context if used by algorithm suite.
 
@@ -124,7 +197,7 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
         verifier = Verifier.from_encoded_point(algorithm=algorithm, encoded_point=encoded_verification_key)
         return verifier.key_bytes()
 
-    def decrypt_materials(self, request):
+    def _decrypt_materials_using_master_key_provider(self, request):
         """Obtains a plaintext data key from one or more encrypted data keys
         using underlying master key provider.
 
@@ -143,3 +216,55 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
         )
 
         return DecryptionMaterials(data_key=data_key, verification_key=verification_key)
+
+    def _decrypt_materials_using_keyring(self, request):
+        """Obtains a plaintext data key from one or more encrypted data keys
+        using underlying keyring.
+
+        :param request: decrypt materials request
+        :type request: aws_encryption_sdk.materials_managers.DecryptionMaterialsRequest
+        :returns: decryption materials
+        :rtype: aws_encryption_sdk.materials_managers.DecryptionMaterials
+        :raises InvalidCryptographicMaterialsError: if keyring cannot complete decryption materials
+        :raises InvalidCryptographicMaterialsError:
+           if decryption materials received from keyring do not match request
+        """
+        verification_key = self._load_verification_key_from_encryption_context(
+            algorithm=request.algorithm, encryption_context=request.encryption_context
+        )
+        decryption_materials = DecryptionMaterials(
+            algorithm=request.algorithm,
+            encryption_context=request.encryption_context.copy(),
+            verification_key=verification_key,
+        )
+
+        final_materials = self.keyring.on_decrypt(
+            decryption_materials=decryption_materials, encrypted_data_keys=request.encrypted_data_keys
+        )
+
+        if not final_materials.is_complete:
+            raise InvalidCryptographicMaterialsError("Decryption materials are incomplete!")
+
+        materials_are_valid = (
+            final_materials.algorithm is request.algorithm,
+            final_materials.encryption_context == request.encryption_context,
+            final_materials.verification_key is verification_key,
+        )
+        if not all(materials_are_valid):
+            raise InvalidCryptographicMaterialsError("Decryption materials do not match reqest!")
+
+        return final_materials
+
+    def decrypt_materials(self, request):
+        """Obtains a plaintext data key from one or more encrypted data keys
+        using underlying master key provider.
+
+        :param request: decrypt materials request
+        :type request: aws_encryption_sdk.materials_managers.DecryptionMaterialsRequest
+        :returns: decryption materials
+        :rtype: aws_encryption_sdk.materials_managers.DecryptionMaterials
+        """
+        if self.master_key_provider is not None:
+            return self._decrypt_materials_using_master_key_provider(request)
+
+        return self._decrypt_materials_using_keyring(request)

--- a/src/aws_encryption_sdk/materials_managers/default.py
+++ b/src/aws_encryption_sdk/materials_managers/default.py
@@ -40,9 +40,9 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
        The *keyring* parameter.
 
     :param MasterKeyProvider master_key_provider: Master key provider to use
-       (either `keyring` or `master_key_provider` is required)
+       (either ``keyring`` or ``master_key_provider`` is required)
     :param Keyring keyring: Keyring to use
-       (either `keyring` or `master_key_provider` is required)
+       (either ``keyring`` or ``master_key_provider`` is required)
     """
 
     algorithm = ALGORITHM

--- a/src/aws_encryption_sdk/materials_managers/default.py
+++ b/src/aws_encryption_sdk/materials_managers/default.py
@@ -252,7 +252,7 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
             final_materials.verification_key is verification_key,
         )
         if not all(materials_are_valid):
-            raise InvalidCryptographicMaterialsError("Decryption materials do not match reqest!")
+            raise InvalidCryptographicMaterialsError("Decryption materials do not match request!")
 
         return final_materials
 

--- a/src/aws_encryption_sdk/materials_managers/default.py
+++ b/src/aws_encryption_sdk/materials_managers/default.py
@@ -131,9 +131,6 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
 
         final_materials = self.keyring.on_encrypt(encryption_materials=encryption_materials)
 
-        if not final_materials.is_complete:
-            raise InvalidCryptographicMaterialsError("Encryption materials are incomplete!")
-
         materials_are_valid = (
             final_materials.algorithm is algorithm,
             final_materials.encryption_context == expected_encryption_context,
@@ -141,6 +138,9 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
         )
         if not all(materials_are_valid):
             raise InvalidCryptographicMaterialsError("Encryption materials do not match request!")
+
+        if not final_materials.is_complete:
+            raise InvalidCryptographicMaterialsError("Encryption materials are incomplete!")
 
         _LOGGER.debug("Post-encrypt encryption context: %s", encryption_context)
 
@@ -233,9 +233,6 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
             decryption_materials=decryption_materials, encrypted_data_keys=request.encrypted_data_keys
         )
 
-        if not final_materials.is_complete:
-            raise InvalidCryptographicMaterialsError("Decryption materials are incomplete!")
-
         materials_are_valid = (
             final_materials.algorithm is request.algorithm,
             final_materials.encryption_context == request.encryption_context,
@@ -243,6 +240,9 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
         )
         if not all(materials_are_valid):
             raise InvalidCryptographicMaterialsError("Decryption materials do not match request!")
+
+        if not final_materials.is_complete:
+            raise InvalidCryptographicMaterialsError("Decryption materials are incomplete!")
 
         return final_materials
 

--- a/src/aws_encryption_sdk/materials_managers/default.py
+++ b/src/aws_encryption_sdk/materials_managers/default.py
@@ -50,6 +50,7 @@ class DefaultCryptoMaterialsManager(CryptoMaterialsManager):
     keyring = attr.ib(default=None, validator=optional(instance_of(Keyring)))
 
     def __attrs_post_init__(self):
+        """Apply input requirements."""
         both = self.master_key_provider is not None and self.keyring is not None
         neither = self.master_key_provider is None and self.keyring is None
 

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """High level AWS Encryption SDK client for streaming objects."""
 from __future__ import division
 

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -69,6 +69,9 @@ _LOGGER = logging.getLogger(__name__)
 class _ClientConfig(object):
     """Parent configuration object for StreamEncryptor and StreamDecryptor objects.
 
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
+
     :param source: Source data to encrypt or decrypt
     :type source: str, bytes, io.IOBase, or file
     :param CryptoMaterialsManager materials_manager:
@@ -314,6 +317,9 @@ class _EncryptionStream(io.IOBase):
 class EncryptorConfig(_ClientConfig):
     """Configuration object for StreamEncryptor class.
 
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
+
     :param source: Source data to encrypt or decrypt
     :type source: str, bytes, io.IOBase, or file
     :param CryptoMaterialsManager materials_manager:
@@ -364,6 +370,9 @@ class StreamEncryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
 
     .. note::
         If config is provided, all other parameters are ignored.
+
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
 
     :param config: Client configuration object (config or individual parameters required)
     :type config: aws_encryption_sdk.streaming_client.EncryptorConfig
@@ -674,6 +683,9 @@ class StreamEncryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
 class DecryptorConfig(_ClientConfig):
     """Configuration object for StreamDecryptor class.
 
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
+
     :param source: Source data to encrypt or decrypt
     :type source: str, bytes, io.IOBase, or file
     :param CryptoMaterialsManager materials_manager:
@@ -709,6 +721,9 @@ class StreamDecryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
 
     .. note::
         If config is provided, all other parameters are ignored.
+
+    .. versionadded:: 1.5.0
+       The *keyring* parameter.
 
     :param config: Client configuration object (config or individual parameters required)
     :type config: aws_encryption_sdk.streaming_client.DecryptorConfig

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -19,8 +19,8 @@ import logging
 import math
 
 import attr
-from attr.validators import instance_of, optional
 import six
+from attr.validators import instance_of, optional
 
 import aws_encryption_sdk.internal.utils
 from aws_encryption_sdk.exceptions import (
@@ -55,11 +55,11 @@ from aws_encryption_sdk.internal.formatting.serialize import (
     serialize_non_framed_open,
 )
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider
+from aws_encryption_sdk.keyrings.base import Keyring
 from aws_encryption_sdk.materials_managers import DecryptionMaterialsRequest, EncryptionMaterialsRequest
 from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
 from aws_encryption_sdk.materials_managers.default import DefaultCryptoMaterialsManager
 from aws_encryption_sdk.structures import MessageHeader
-from aws_encryption_sdk.keyrings.base import Keyring
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,18 +87,10 @@ class _ClientConfig(object):
     """
 
     source = attr.ib(hash=True, converter=aws_encryption_sdk.internal.utils.prep_stream_data)
-    materials_manager = attr.ib(
-        hash=True, default=None, validator=optional(instance_of(CryptoMaterialsManager))
-    )
-    keyring = attr.ib(
-        default=None, validator=optional(instance_of(Keyring))
-    )
-    key_provider = attr.ib(
-        hash=True, default=None, validator=optional(instance_of(MasterKeyProvider))
-    )
-    source_length = attr.ib(
-        hash=True, default=None, validator=optional(instance_of(six.integer_types))
-    )
+    materials_manager = attr.ib(hash=True, default=None, validator=optional(instance_of(CryptoMaterialsManager)))
+    keyring = attr.ib(default=None, validator=optional(instance_of(Keyring)))
+    key_provider = attr.ib(hash=True, default=None, validator=optional(instance_of(MasterKeyProvider)))
+    source_length = attr.ib(hash=True, default=None, validator=optional(instance_of(six.integer_types)))
     line_length = attr.ib(
         hash=True, default=LINE_LENGTH, validator=instance_of(six.integer_types)
     )  # DEPRECATED: Value is no longer configurable here.  Parameter left here to avoid breaking consumers.

--- a/test/functional/test_client.py
+++ b/test/functional/test_client.py
@@ -44,7 +44,6 @@ from ..unit.unit_test_utils import (
     ephemeral_raw_aes_keyring,
     ephemeral_raw_aes_master_key,
     ephemeral_raw_rsa_keyring,
-    ephemeral_raw_rsa_master_key,
     raw_rsa_mkps_from_keyring,
 )
 
@@ -410,12 +409,22 @@ def _raw_rsa(include_pre_sha2=True, include_sha2=True):
             id="raw RSA keyring -- public encrypt, private decrypt -- {}".format(wrapping_algorithm.name),
         )
         private_mkp, public_mkp = raw_rsa_mkps_from_keyring(private_keyring)
+
         yield pytest.param(
             "key_provider",
             private_mkp,
             "keyring",
             private_keyring,
-            id="raw RSA keyring -- encrypt with master key provider and decrypt with keyring -- {}".format(
+            id="raw RSA keyring -- private master key provider encrypt and private keyring decrypt -- {}".format(
+                wrapping_algorithm
+            ),
+        )
+        yield pytest.param(
+            "key_provider",
+            public_mkp,
+            "keyring",
+            private_keyring,
+            id="raw RSA keyring -- public master key provider encrypt and private keyring decrypt -- {}".format(
                 wrapping_algorithm
             ),
         )
@@ -424,7 +433,16 @@ def _raw_rsa(include_pre_sha2=True, include_sha2=True):
             private_keyring,
             "key_provider",
             private_mkp,
-            id="raw RSA keyring -- encrypt with keyring and decrypt with master key provider -- {}".format(
+            id="raw RSA keyring -- private keyring encrypt and private master key provider decrypt -- {}".format(
+                wrapping_algorithm
+            ),
+        )
+        yield pytest.param(
+            "keyring",
+            public_keyring,
+            "key_provider",
+            private_mkp,
+            id="raw RSA keyring -- public keyring encrypt and private master key provider decrypt -- {}".format(
                 wrapping_algorithm
             ),
         )

--- a/test/functional/test_client.py
+++ b/test/functional/test_client.py
@@ -14,8 +14,8 @@
 from __future__ import division
 
 import io
-import logging
 import itertools
+import logging
 
 import attr
 import botocore.client
@@ -35,12 +35,17 @@ from aws_encryption_sdk.identifiers import Algorithm, EncryptionKeyType, Wrappin
 from aws_encryption_sdk.internal.crypto.wrapping_keys import WrappingKey
 from aws_encryption_sdk.internal.defaults import LINE_LENGTH
 from aws_encryption_sdk.internal.formatting.encryption_context import serialize_encryption_context
-from aws_encryption_sdk.key_providers.base import MasterKeyProviderConfig, MasterKeyProvider
+from aws_encryption_sdk.key_providers.base import MasterKeyProvider, MasterKeyProviderConfig
 from aws_encryption_sdk.key_providers.raw import RawMasterKeyProvider
-from aws_encryption_sdk.materials_managers import DecryptionMaterialsRequest, EncryptionMaterialsRequest
 from aws_encryption_sdk.keyrings.raw import RawRSAKeyring
+from aws_encryption_sdk.materials_managers import DecryptionMaterialsRequest, EncryptionMaterialsRequest
 
-from ..unit.unit_test_utils import ephemeral_raw_aes_keyring, ephemeral_raw_rsa_keyring
+from ..unit.unit_test_utils import (
+    ephemeral_raw_aes_keyring,
+    ephemeral_raw_aes_master_key,
+    ephemeral_raw_rsa_keyring,
+    ephemeral_raw_rsa_master_key,
+)
 
 pytestmark = [pytest.mark.functional, pytest.mark.local]
 
@@ -320,31 +325,37 @@ def test_encrypt_ciphertext_message(frame_length, algorithm, encryption_context)
 
 
 def _raw_aes():
-    for symmetric_algorithm in (WrappingAlgorithm.AES_128_GCM_IV12_TAG16_NO_PADDING, WrappingAlgorithm.AES_192_GCM_IV12_TAG16_NO_PADDING, WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING):
-        yield pytest.param(
-            "key_provider",
-            build_fake_raw_key_provider(symmetric_algorithm, EncryptionKeyType.SYMMETRIC),
-            build_fake_raw_key_provider(symmetric_algorithm, EncryptionKeyType.SYMMETRIC),
-            id="raw AES master key provider -- {}".format(symmetric_algorithm.name)
-        )
-        keyring = ephemeral_raw_aes_keyring(symmetric_algorithm)
-        yield pytest.param(
-            "keyring",
-            keyring,
-            keyring,
-            id="raw AES keyring -- {}".format(symmetric_algorithm.name)
-        )
-
-    for wrapping_algorithm, encryption_key_type, decryption_key_type in (
-        (WrappingAlgorithm.RSA_PKCS1, EncryptionKeyType.PRIVATE, EncryptionKeyType.PRIVATE),
-        (WrappingAlgorithm.RSA_PKCS1, EncryptionKeyType.PUBLIC, EncryptionKeyType.PRIVATE),
-        (WrappingAlgorithm.RSA_OAEP_SHA1_MGF1, EncryptionKeyType.PRIVATE, EncryptionKeyType.PRIVATE),
-        (WrappingAlgorithm.RSA_OAEP_SHA1_MGF1, EncryptionKeyType.PUBLIC, EncryptionKeyType.PRIVATE),
+    for symmetric_algorithm in (
+        WrappingAlgorithm.AES_128_GCM_IV12_TAG16_NO_PADDING,
+        WrappingAlgorithm.AES_192_GCM_IV12_TAG16_NO_PADDING,
+        WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
     ):
         yield pytest.param(
             "key_provider",
-            build_fake_raw_key_provider(wrapping_algorithm, encryption_key_type),
-            build_fake_raw_key_provider(wrapping_algorithm, decryption_key_type)
+            build_fake_raw_key_provider(symmetric_algorithm, EncryptionKeyType.SYMMETRIC),
+            "key_provider",
+            build_fake_raw_key_provider(symmetric_algorithm, EncryptionKeyType.SYMMETRIC),
+            id="raw AES master key provider -- {}".format(symmetric_algorithm.name),
+        )
+        keyring = ephemeral_raw_aes_keyring(symmetric_algorithm)
+        yield pytest.param(
+            "keyring", keyring, "keyring", keyring, id="raw AES keyring -- {}".format(symmetric_algorithm.name)
+        )
+
+        mkp = ephemeral_raw_aes_master_key(wrapping_algorithm=symmetric_algorithm, key=keyring._wrapping_key)
+        yield pytest.param(
+            "key_provider",
+            mkp,
+            "keyring",
+            keyring,
+            id="raw AES -- encrypt with master key provider and decrypt with keyring -- {}".format(symmetric_algorithm),
+        )
+        yield pytest.param(
+            "keyring",
+            keyring,
+            "key_provider",
+            mkp,
+            id="raw AES -- encrypt with keyring and decrypt with master key provider -- {}".format(symmetric_algorithm),
         )
 
 
@@ -353,23 +364,27 @@ def _raw_rsa(include_pre_sha2=True, include_sha2=True):
     if include_pre_sha2:
         wrapping_algorithms.extend([WrappingAlgorithm.RSA_PKCS1, WrappingAlgorithm.RSA_OAEP_SHA1_MGF1])
     if include_sha2:
-        wrapping_algorithms.extend([
-            WrappingAlgorithm.RSA_OAEP_SHA256_MGF1,
-            WrappingAlgorithm.RSA_OAEP_SHA384_MGF1,
-            WrappingAlgorithm.RSA_OAEP_SHA512_MGF1
-        ])
+        wrapping_algorithms.extend(
+            [
+                WrappingAlgorithm.RSA_OAEP_SHA256_MGF1,
+                WrappingAlgorithm.RSA_OAEP_SHA384_MGF1,
+                WrappingAlgorithm.RSA_OAEP_SHA512_MGF1,
+            ]
+        )
     for wrapping_algorithm in wrapping_algorithms:
         yield pytest.param(
             "key_provider",
             build_fake_raw_key_provider(wrapping_algorithm, EncryptionKeyType.PRIVATE),
+            "key_provider",
             build_fake_raw_key_provider(wrapping_algorithm, EncryptionKeyType.PRIVATE),
-            id="raw AES master key provider -- private encrypt, private decrypt -- {}".format(wrapping_algorithm.name)
+            id="raw RSA master key provider -- private encrypt, private decrypt -- {}".format(wrapping_algorithm.name),
         )
         yield pytest.param(
             "key_provider",
             build_fake_raw_key_provider(wrapping_algorithm, EncryptionKeyType.PUBLIC),
+            "key_provider",
             build_fake_raw_key_provider(wrapping_algorithm, EncryptionKeyType.PRIVATE),
-            id="raw AES master key provider -- public encrypt, private decrypt -- {}".format(wrapping_algorithm.name)
+            id="raw RSA master key provider -- public encrypt, private decrypt -- {}".format(wrapping_algorithm.name),
         )
 
         private_keyring = ephemeral_raw_rsa_keyring(wrapping_algorithm=wrapping_algorithm)
@@ -377,19 +392,21 @@ def _raw_rsa(include_pre_sha2=True, include_sha2=True):
             key_namespace=private_keyring.key_namespace,
             key_name=private_keyring.key_name,
             wrapping_algorithm=wrapping_algorithm,
-            public_wrapping_key=private_keyring._private_wrapping_key.public_key()
+            public_wrapping_key=private_keyring._private_wrapping_key.public_key(),
         )
         yield pytest.param(
             "keyring",
             private_keyring,
+            "keyring",
             private_keyring,
-            id="raw AES keyring -- private encrypt, private decrypt -- {}".format(wrapping_algorithm.name)
+            id="raw RSA keyring -- private encrypt, private decrypt -- {}".format(wrapping_algorithm.name),
         )
         yield pytest.param(
             "keyring",
             public_keyring,
+            "keyring",
             private_keyring,
-            id="raw AES keyring -- public encrypt, private decrypt -- {}".format(wrapping_algorithm.name)
+            id="raw RSA keyring -- public encrypt, private decrypt -- {}".format(wrapping_algorithm.name),
         )
 
 
@@ -399,11 +416,13 @@ def assert_key_not_logged(provider, log_capture):
             assert repr(member.config.wrapping_key._wrapping_key)[2:-1] not in log_capture
 
 
-def run_raw_provider_check(log_capturer, param_name, encrypting_provider, decrypting_provider):
+def run_raw_provider_check(
+    log_capturer, encrypt_param_name, encrypting_provider, decrypt_param_name, decrypting_provider
+):
     log_capturer.set_level(logging.DEBUG)
 
-    encrypt_kwargs = {param_name: encrypting_provider}
-    decrypt_kwargs = {param_name: decrypting_provider}
+    encrypt_kwargs = {encrypt_param_name: encrypting_provider}
+    decrypt_kwargs = {decrypt_param_name: decrypting_provider}
 
     ciphertext, _ = aws_encryption_sdk.encrypt(
         source=VALUES["plaintext_128"],
@@ -418,22 +437,25 @@ def run_raw_provider_check(log_capturer, param_name, encrypting_provider, decryp
 
 
 @pytest.mark.parametrize(
-    "param_name, encrypting_provider, decrypting_provider",
-    itertools.chain.from_iterable((_raw_aes(), _raw_rsa(include_sha2=False)))
+    "encrypt_param_name, encrypting_provider, decrypt_param_name, decrypting_provider",
+    itertools.chain.from_iterable((_raw_aes(), _raw_rsa(include_sha2=False))),
 )
-def test_encryption_cycle_raw_mkp(caplog, param_name, encrypting_provider, decrypting_provider):
-    run_raw_provider_check(caplog, param_name, encrypting_provider, decrypting_provider)
+def test_encryption_cycle_raw_mkp(
+    caplog, encrypt_param_name, encrypting_provider, decrypt_param_name, decrypting_provider
+):
+    run_raw_provider_check(caplog, encrypt_param_name, encrypting_provider, decrypt_param_name, decrypting_provider)
 
 
 @pytest.mark.skipif(
     not _mgf1_sha256_supported(), reason="MGF1-SHA2 not supported by this backend: OpenSSL required v1.0.2+"
 )
 @pytest.mark.parametrize(
-    "param_name, encrypting_provider, decrypting_provider",
-    _raw_rsa(include_pre_sha2=False)
+    "encrypt_param_name, encrypting_provider, decrypt_param_name, decrypting_provider", _raw_rsa(include_pre_sha2=False)
 )
-def test_encryption_cycle_raw_mkp_openssl_102_plus(caplog, param_name, encrypting_provider, decrypting_provider):
-    run_raw_provider_check(caplog, param_name, encrypting_provider, decrypting_provider)
+def test_encryption_cycle_raw_mkp_openssl_102_plus(
+    caplog, encrypt_param_name, encrypting_provider, decrypt_param_name, decrypting_provider
+):
+    run_raw_provider_check(caplog, encrypt_param_name, encrypting_provider, decrypt_param_name, decrypting_provider)
 
 
 @pytest.mark.parametrize(

--- a/test/functional/test_client.py
+++ b/test/functional/test_client.py
@@ -45,6 +45,7 @@ from ..unit.unit_test_utils import (
     ephemeral_raw_aes_master_key,
     ephemeral_raw_rsa_keyring,
     ephemeral_raw_rsa_master_key,
+    raw_rsa_mkps_from_keyring,
 )
 
 pytestmark = [pytest.mark.functional, pytest.mark.local]
@@ -407,6 +408,25 @@ def _raw_rsa(include_pre_sha2=True, include_sha2=True):
             "keyring",
             private_keyring,
             id="raw RSA keyring -- public encrypt, private decrypt -- {}".format(wrapping_algorithm.name),
+        )
+        private_mkp, public_mkp = raw_rsa_mkps_from_keyring(private_keyring)
+        yield pytest.param(
+            "key_provider",
+            private_mkp,
+            "keyring",
+            private_keyring,
+            id="raw RSA keyring -- encrypt with master key provider and decrypt with keyring -- {}".format(
+                wrapping_algorithm
+            ),
+        )
+        yield pytest.param(
+            "keyring",
+            private_keyring,
+            "key_provider",
+            private_mkp,
+            id="raw RSA keyring -- encrypt with keyring and decrypt with master key provider -- {}".format(
+                wrapping_algorithm
+            ),
         )
 
 

--- a/test/functional/test_client.py
+++ b/test/functional/test_client.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Functional test suite for aws_encryption_sdk.kms_thick_client"""
 from __future__ import division
 

--- a/test/integration/test_client.py
+++ b/test/integration/test_client.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Integration test suite for `aws_encryption_sdk`."""
 import io
 import logging

--- a/test/integration/test_client.py
+++ b/test/integration/test_client.py
@@ -64,12 +64,13 @@ def test_encrypt_verify_user_agent_kms_master_key(caplog):
 
 def test_remove_bad_client():
     test = KMSMasterKeyProvider()
-    test.add_regional_client("us-fakey-12")
+    fake_region = "us-fakey-12"
+    test.add_regional_client(fake_region)
 
     with pytest.raises(BotoCoreError):
-        test._regional_clients["us-fakey-12"].list_keys()
+        test._regional_clients[fake_region].list_keys()
 
-    assert not test._regional_clients
+    assert fake_region not in test._regional_clients
 
 
 def test_regional_client_does_not_modify_botocore_session(caplog):

--- a/test/unit/materials_managers/test_caching.py
+++ b/test/unit/materials_managers/test_caching.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Unit test suite for CachingCryptoMaterialsManager"""
 import pytest
 from mock import MagicMock, sentinel

--- a/test/unit/materials_managers/test_default.py
+++ b/test/unit/materials_managers/test_default.py
@@ -29,7 +29,7 @@ from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, MasterKeyIn
 
 from ..unit_test_utils import (
     BrokenKeyring,
-    OnlyGenerateKeyring,
+    NoEncryptedDataKeysKeyring,
     ephemeral_raw_aes_keyring,
     ephemeral_raw_aes_master_key,
 )
@@ -267,7 +267,7 @@ def test_decrypt_materials(mocker, patch_for_dcmm_decrypt):
 def test_encrypt_with_keyring_materials_incomplete():
     raw_aes256_keyring = ephemeral_raw_aes_keyring(WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING)
 
-    encrypt_cmm = DefaultCryptoMaterialsManager(keyring=OnlyGenerateKeyring(inner_keyring=raw_aes256_keyring))
+    encrypt_cmm = DefaultCryptoMaterialsManager(keyring=NoEncryptedDataKeysKeyring(inner_keyring=raw_aes256_keyring))
 
     encryption_materials_request = EncryptionMaterialsRequest(encryption_context={}, frame_length=1024)
 

--- a/test/unit/materials_managers/test_default.py
+++ b/test/unit/materials_managers/test_default.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Test suite for aws_encryption_sdk.materials_managers.default"""
 import pytest
 from mock import MagicMock, sentinel

--- a/test/unit/materials_managers/test_default.py
+++ b/test/unit/materials_managers/test_default.py
@@ -19,17 +19,11 @@ from aws_encryption_sdk.exceptions import MasterKeyProviderError, SerializationE
 from aws_encryption_sdk.identifiers import Algorithm
 from aws_encryption_sdk.internal.defaults import ALGORITHM, ENCODED_SIGNER_KEY
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider
-from aws_encryption_sdk.keyrings.base import Keyring
 from aws_encryption_sdk.materials_managers import EncryptionMaterials
 from aws_encryption_sdk.materials_managers.default import DefaultCryptoMaterialsManager
 from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, MasterKeyInfo, RawDataKey
 
-from ..unit_test_utils import (
-    ephemeral_raw_aes_keyring,
-    ephemeral_raw_aes_master_key,
-    ephemeral_raw_rsa_keyring,
-    ephemeral_raw_rsa_master_key,
-)
+from ..unit_test_utils import ephemeral_raw_aes_keyring, ephemeral_raw_aes_master_key
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -33,7 +33,7 @@ from aws_encryption_sdk.materials_managers import DecryptionMaterials, Encryptio
 from aws_encryption_sdk.structures import EncryptedDataKey, KeyringTrace, MasterKeyInfo, RawDataKey
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from typing import Iterable  # noqa pylint: disable=unused-import
+    from typing import Iterable, Optional  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
@@ -433,7 +433,7 @@ def ephemeral_raw_rsa_master_key(size=4096):
 
 
 def ephemeral_raw_rsa_keyring(size=4096, wrapping_algorithm=WrappingAlgorithm.RSA_OAEP_SHA256_MGF1):
-    # type: (int, WrappingAlgorithm) -> RawRSAKeyring
+    # type: (int, WrappingAlgorithm, Optional[bytes]) -> RawRSAKeyring
     key_bytes = _generate_rsa_key_bytes(size)
     return RawRSAKeyring.from_pem_encoding(
         key_namespace="fake",
@@ -443,25 +443,25 @@ def ephemeral_raw_rsa_keyring(size=4096, wrapping_algorithm=WrappingAlgorithm.RS
     )
 
 
-def ephemeral_raw_aes_master_key(wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING):
-    # type: (WrappingAlgorithm) -> RawMasterKey
+def ephemeral_raw_aes_master_key(wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING, key=None):
+    # type: (WrappingAlgorithm, Optional[bytes]) -> RawMasterKey
     key_length = wrapping_algorithm.algorithm.data_key_len
-    key = os.urandom(key_length)
+    if key is None:
+        key = os.urandom(key_length)
     return RawMasterKey(
         provider_id="fake",
         key_id="aes-{}".format(key_length * 8).encode("utf-8"),
         wrapping_key=WrappingKey(
-            wrapping_algorithm=wrapping_algorithm,
-            wrapping_key=key,
-            wrapping_key_type=EncryptionKeyType.SYMMETRIC,
+            wrapping_algorithm=wrapping_algorithm, wrapping_key=key, wrapping_key_type=EncryptionKeyType.SYMMETRIC,
         ),
     )
 
 
-def ephemeral_raw_aes_keyring(wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING):
-    # type: (WrappingAlgorithm) -> RawAESKeyring
+def ephemeral_raw_aes_keyring(wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING, key=None):
+    # type: (WrappingAlgorithm, Optional[bytes]) -> RawAESKeyring
     key_length = wrapping_algorithm.algorithm.data_key_len
-    key = os.urandom(key_length)
+    if key is None:
+        key = os.urandom(key_length)
     return RawAESKeyring(
         key_namespace="fake",
         key_name="aes-{}".format(key_length * 8).encode("utf-8"),

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -1,15 +1,5 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Utility functions to handle common test framework functions."""
 import base64
 import copy

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -642,7 +642,7 @@ class BrokenKeyring(Keyring):
 
 
 @attr.s
-class OnlyGenerateKeyring(Keyring):
+class NoEncryptedDataKeysKeyring(Keyring):
     """Keyring that wraps another keyring and removes any encrypted data keys."""
 
     _inner_keyring = attr.ib(validator=instance_of(Keyring))


### PR DESCRIPTION
*Issue #, if available:* #211 

*Description of changes:*

This adds support for using keyrings to `DefaultCryptographicMaterialsManager` as well as the appropriate passthroughs via `CachingCryptographicMaterialsManager` and the encrypt/decrypt entry points.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

