### PR TITLE
Expose keyring trace in results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,24 @@
 Changelog
 *********
 
+1.5.0 -- 2020-xx-xx
+===================
+
+Major Features
+--------------
+
+* Add Keyrings
+* Change one-step APIs to return a :class:`CryptoResult` rather than a tuple.
+    * Changed APIs: ``aws_encryption_sdk.encrypt`` and ``aws_encryption_sdk.decrypt``.
+
+.. note::
+
+    For backwards compatibility,
+    :class:`CryptoResult` also unpacks like a 2-member tuple.
+    This allows for backwards compatibility with the previous outputs
+    so this change should not break any existing consumers.
+
+
 1.4.1 -- 2019-09-20
 ===================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,16 +8,17 @@ Changelog
 Major Features
 --------------
 
-* Add Keyrings
+* Add `keyrings`_.
 * Change one-step APIs to return a :class:`CryptoResult` rather than a tuple.
-    * Changed APIs: ``aws_encryption_sdk.encrypt`` and ``aws_encryption_sdk.decrypt``.
+    * Modified APIs: ``aws_encryption_sdk.encrypt`` and ``aws_encryption_sdk.decrypt``.
 
 .. note::
 
     For backwards compatibility,
     :class:`CryptoResult` also unpacks like a 2-member tuple.
     This allows for backwards compatibility with the previous outputs
-    so this change should not break any existing consumers.
+    so this change should not break any existing consumers
+    unless you are specifically relying on the output being an instance of :class:`tuple`.
 
 
 1.4.1 -- 2019-09-20
@@ -211,3 +212,4 @@ Minor
 .. _pylint: https://www.pylint.org/
 .. _flake8: http://flake8.pycqa.org/en/latest/
 .. _doc8: https://launchpad.net/doc8
+.. _keyrings: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/choose-keyring.html

--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -14,6 +14,9 @@ from aws_encryption_sdk.streaming_client import (  # noqa
     StreamDecryptor,
     StreamEncryptor,
 )
+from aws_encryption_sdk.structures import CryptoResult
+
+__all__ = ("encrypt", "decrypt", "stream")
 
 
 def encrypt(**kwargs):
@@ -25,6 +28,13 @@ def encrypt(**kwargs):
 
     .. versionadded:: 1.5.0
        The *keyring* parameter.
+
+    .. versionadded:: 1.5.0
+
+        For backwards compatibility,
+        the new :class:`CryptoResult` return value also unpacks like a 2-member tuple.
+        This allows for backwards compatibility with the previous outputs
+        so this change should not break any existing consumers.
 
     .. code:: python
 
@@ -67,12 +77,13 @@ def encrypt(**kwargs):
     :param algorithm: Algorithm to use for encryption
     :type algorithm: aws_encryption_sdk.identifiers.Algorithm
     :param int frame_length: Frame length in bytes
-    :returns: Tuple containing the encrypted ciphertext and the message header object
-    :rtype: tuple of bytes and :class:`aws_encryption_sdk.structures.MessageHeader`
+    :returns: Encrypted message, message metadata (header), and keyring trace
+    :rtype: CryptoResult
     """
     with StreamEncryptor(**kwargs) as encryptor:
         ciphertext = encryptor.read()
-    return ciphertext, encryptor.header
+
+    return CryptoResult(result=ciphertext, header=encryptor.header, keyring_trace=encryptor.keyring_trace)
 
 
 def decrypt(**kwargs):
@@ -84,6 +95,13 @@ def decrypt(**kwargs):
 
     .. versionadded:: 1.5.0
        The *keyring* parameter.
+
+    .. versionadded:: 1.5.0
+
+        For backwards compatibility,
+        the new :class:`CryptoResult` return value also unpacks like a 2-member tuple.
+        This allows for backwards compatibility with the previous outputs
+        so this change should not break any existing consumers.
 
     .. code:: python
 
@@ -117,12 +135,13 @@ def decrypt(**kwargs):
 
     :param int max_body_length: Maximum frame size (or content length for non-framed messages)
         in bytes to read from ciphertext message.
-    :returns: Tuple containing the decrypted plaintext and the message header object
-    :rtype: tuple of bytes and :class:`aws_encryption_sdk.structures.MessageHeader`
+    :returns: Decrypted plaintext, message metadata (header), and keyring trace
+    :rtype: CryptoResult
     """
     with StreamDecryptor(**kwargs) as decryptor:
         plaintext = decryptor.read()
-    return plaintext, decryptor.header
+
+    return CryptoResult(result=plaintext, header=decryptor.header, keyring_trace=decryptor.keyring_trace)
 
 
 def stream(**kwargs):
@@ -182,6 +201,3 @@ def stream(**kwargs):
         return _stream_map[mode.lower()](**kwargs)
     except KeyError:
         raise ValueError("Unsupported mode: {}".format(mode))
-
-
-__all__ = ("encrypt", "decrypt", "stream")

--- a/src/aws_encryption_sdk/materials_managers/__init__.py
+++ b/src/aws_encryption_sdk/materials_managers/__init__.py
@@ -25,7 +25,7 @@ from aws_encryption_sdk.internal.utils.streams import ROStream
 from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, KeyringTrace, RawDataKey
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from typing import Any, FrozenSet, Iterable, Tuple, Union  # noqa pylint: disable=unused-import
+    from typing import Any, Iterable, Tuple, Union  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
@@ -238,10 +238,10 @@ class EncryptionMaterials(CryptographicMaterials):
 
     @property
     def encrypted_data_keys(self):
-        # type: () -> FrozenSet[EncryptedDataKey]
+        # type: () -> Tuple[EncryptedDataKey]
         """Return a read-only version of the encrypted data keys.
 
-        :rtype: frozenset
+        :rtype: Tuple[EncryptedDataKey]
         """
         return tuple(self._encrypted_data_keys)
 

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -137,6 +137,7 @@ class _EncryptionStream(io.IOBase):
     _message_prepped = None  # type: bool
     source_stream = None
     _stream_length = None  # type: int
+    keyring_trace = ()
 
     def __new__(cls, **kwargs):
         """Perform necessary handling for _EncryptionStream instances that should be
@@ -443,6 +444,7 @@ class StreamEncryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
         self._encryption_materials = self.config.materials_manager.get_encryption_materials(
             request=encryption_materials_request
         )
+        self.keyring_trace = self._encryption_materials.keyring_trace
 
         if self.config.algorithm is not None and self._encryption_materials.algorithm != self.config.algorithm:
             raise ActionNotAllowedError(
@@ -779,6 +781,8 @@ class StreamDecryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
             encryption_context=header.encryption_context,
         )
         decryption_materials = self.config.materials_manager.decrypt_materials(request=decrypt_materials_request)
+        self.keyring_trace = decryption_materials.keyring_trace
+
         if decryption_materials.verification_key is None:
             self.verifier = None
         else:

--- a/src/aws_encryption_sdk/structures.py
+++ b/src/aws_encryption_sdk/structures.py
@@ -113,8 +113,7 @@ class KeyringTrace(object):
     .. versionadded:: 1.5.0
 
     :param MasterKeyInfo wrapping_key: Wrapping key used
-    :param flags: Actions performed
-    :type flags: set of :class:`KeyringTraceFlag`
+    :param Set[KeyringTraceFlag] flags: Actions performed
     """
 
     wrapping_key = attr.ib(validator=instance_of(MasterKeyInfo))
@@ -126,19 +125,14 @@ class MessageHeader(object):
     # pylint: disable=too-many-instance-attributes
     """Deserialized message header object.
 
-    :param version: Message format version, per spec
-    :type version: SerializationVersion
-    :param type: Message content type, per spec
-    :type type: ObjectType
-    :param algorithm: Algorithm to use for encryption
-    :type algorithm: Algorithm
+    :param SerializationVersion version: Message format version, per spec
+    :param ObjectType type: Message content type, per spec
+    :param AlgorithmSuite algorithm: Algorithm to use for encryption
     :param bytes message_id: Message ID
-    :param dict encryption_context: Dictionary defining encryption context
-    :param encrypted_data_keys: Encrypted data keys
-    :type encrypted_data_keys: set of :class:`aws_encryption_sdk.structures.EncryptedDataKey`
-    :param content_type: Message content framing type (framed/non-framed)
-    :type content_type: ContentType
-    :param bytes content_aad_length: empty
+    :param Dict[str,str] encryption_context: Dictionary defining encryption context
+    :param Sequence[EncryptedDataKey] encrypted_data_keys: Encrypted data keys
+    :param ContentType content_type: Message content framing type (framed/non-framed)
+    :param int content_aad_length: empty
     :param int header_iv_length: Bytes in Initialization Vector value found in header
     :param int frame_length: Length of message frame in bytes
     """

--- a/test/functional/test_client.py
+++ b/test/functional/test_client.py
@@ -486,15 +486,9 @@ def test_encryption_cycle_raw_mkp_openssl_102_plus(
     run_raw_provider_check(caplog, encrypt_param_name, encrypting_provider, decrypt_param_name, decrypting_provider)
 
 
-@pytest.mark.parametrize(
-    "frame_length, algorithm, encryption_context",
-    [
-        [frame_length, algorithm_suite, encryption_context]
-        for frame_length in VALUES["frame_lengths"]
-        for algorithm_suite in Algorithm
-        for encryption_context in [{}, VALUES["encryption_context"]]
-    ],
-)
+@pytest.mark.parametrize("frame_length", VALUES["frame_lengths"])
+@pytest.mark.parametrize("algorithm", Algorithm)
+@pytest.mark.parametrize("encryption_context", [{}, VALUES["encryption_context"]])
 def test_encryption_cycle_oneshot_kms(frame_length, algorithm, encryption_context):
     key_provider = fake_kms_key_provider(algorithm.kdf_input_len)
 
@@ -511,15 +505,9 @@ def test_encryption_cycle_oneshot_kms(frame_length, algorithm, encryption_contex
     assert plaintext == VALUES["plaintext_128"] * 10
 
 
-@pytest.mark.parametrize(
-    "frame_length, algorithm, encryption_context",
-    [
-        [frame_length, algorithm_suite, encryption_context]
-        for frame_length in VALUES["frame_lengths"]
-        for algorithm_suite in Algorithm
-        for encryption_context in [{}, VALUES["encryption_context"]]
-    ],
-)
+@pytest.mark.parametrize("frame_length", VALUES["frame_lengths"])
+@pytest.mark.parametrize("algorithm", Algorithm)
+@pytest.mark.parametrize("encryption_context", [{}, VALUES["encryption_context"]])
 def test_encryption_cycle_stream_kms(frame_length, algorithm, encryption_context):
     key_provider = fake_kms_key_provider(algorithm.kdf_input_len)
 

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -17,7 +17,12 @@ from mock import MagicMock, patch, sentinel
 import aws_encryption_sdk
 import aws_encryption_sdk.internal.defaults
 
+from .vectors import VALUES
+
 pytestmark = [pytest.mark.unit, pytest.mark.local]
+_CIPHERTEXT = b"CIPHERTEXT"
+_PLAINTEXT = b"PLAINTEXT"
+_HEADER = VALUES["deserialized_header_frame"]
 
 
 class TestAwsEncryptionSdk(object):
@@ -27,16 +32,16 @@ class TestAwsEncryptionSdk(object):
         self.mock_stream_encryptor_patcher = patch("aws_encryption_sdk.StreamEncryptor")
         self.mock_stream_encryptor = self.mock_stream_encryptor_patcher.start()
         self.mock_stream_encryptor_instance = MagicMock()
-        self.mock_stream_encryptor_instance.read.return_value = sentinel.ciphertext
-        self.mock_stream_encryptor_instance.header = sentinel.header
+        self.mock_stream_encryptor_instance.read.return_value = _CIPHERTEXT
+        self.mock_stream_encryptor_instance.header = _HEADER
         self.mock_stream_encryptor.return_value = self.mock_stream_encryptor_instance
         self.mock_stream_encryptor_instance.__enter__.return_value = self.mock_stream_encryptor_instance
         # Set up StreamDecryptor patch
         self.mock_stream_decryptor_patcher = patch("aws_encryption_sdk.StreamDecryptor")
         self.mock_stream_decryptor = self.mock_stream_decryptor_patcher.start()
         self.mock_stream_decryptor_instance = MagicMock()
-        self.mock_stream_decryptor_instance.read.return_value = sentinel.plaintext
-        self.mock_stream_decryptor_instance.header = sentinel.header
+        self.mock_stream_decryptor_instance.read.return_value = _PLAINTEXT
+        self.mock_stream_decryptor_instance.header = _HEADER
         self.mock_stream_decryptor.return_value = self.mock_stream_decryptor_instance
         self.mock_stream_decryptor_instance.__enter__.return_value = self.mock_stream_decryptor_instance
         yield
@@ -47,14 +52,14 @@ class TestAwsEncryptionSdk(object):
     def test_encrypt(self):
         test_ciphertext, test_header = aws_encryption_sdk.encrypt(a=sentinel.a, b=sentinel.b, c=sentinel.b)
         self.mock_stream_encryptor.called_once_with(a=sentinel.a, b=sentinel.b, c=sentinel.b)
-        assert test_ciphertext is sentinel.ciphertext
-        assert test_header is sentinel.header
+        assert test_ciphertext is _CIPHERTEXT
+        assert test_header is _HEADER
 
     def test_decrypt(self):
         test_plaintext, test_header = aws_encryption_sdk.decrypt(a=sentinel.a, b=sentinel.b, c=sentinel.b)
         self.mock_stream_encryptor.called_once_with(a=sentinel.a, b=sentinel.b, c=sentinel.b)
-        assert test_plaintext is sentinel.plaintext
-        assert test_header is sentinel.header
+        assert test_plaintext is _PLAINTEXT
+        assert test_header is _HEADER
 
     def test_stream_encryptor_e(self):
         test = aws_encryption_sdk.stream(mode="e", a=sentinel.a, b=sentinel.b, c=sentinel.b)

--- a/test/unit/test_structures.py
+++ b/test/unit/test_structures.py
@@ -13,8 +13,16 @@
 """Unit test suite for aws_encryption_sdk.structures"""
 import pytest
 
-from aws_encryption_sdk.identifiers import Algorithm, ContentType, ObjectType, SerializationVersion
-from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, MasterKeyInfo, MessageHeader, RawDataKey
+from aws_encryption_sdk.identifiers import Algorithm, ContentType, KeyringTraceFlag, ObjectType, SerializationVersion
+from aws_encryption_sdk.structures import (
+    CryptoResult,
+    DataKey,
+    EncryptedDataKey,
+    KeyringTrace,
+    MasterKeyInfo,
+    MessageHeader,
+    RawDataKey,
+)
 
 from .unit_test_utils import all_invalid_kwargs, all_valid_kwargs
 
@@ -55,6 +63,35 @@ VALID_KWARGS = {
     EncryptedDataKey: [
         dict(
             key_provider=MasterKeyInfo(provider_id="asjnoa", key_info=b"aosjfoaiwej"), encrypted_data_key=b"aisofiawjef"
+        )
+    ],
+    KeyringTrace: [
+        dict(
+            wrapping_key=MasterKeyInfo(provider_id="foo", key_info=b"bar"),
+            flags={KeyringTraceFlag.WRAPPING_KEY_ENCRYPTED_DATA_KEY},
+        )
+    ],
+    CryptoResult: [
+        dict(
+            result=b"super secret stuff",
+            header=MessageHeader(
+                version=SerializationVersion.V1,
+                type=ObjectType.CUSTOMER_AE_DATA,
+                algorithm=Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+                message_id=b"aosiejfoaiwej",
+                encryption_context={},
+                encrypted_data_keys=set([]),
+                content_type=ContentType.FRAMED_DATA,
+                content_aad_length=32456,
+                header_iv_length=32456,
+                frame_length=234567,
+            ),
+            keyring_trace=(
+                KeyringTrace(
+                    wrapping_key=MasterKeyInfo(provider_id="foo", key_info=b"bar"),
+                    flags={KeyringTraceFlag.WRAPPING_KEY_ENCRYPTED_DATA_KEY},
+                ),
+            ),
         )
     ],
 }
@@ -134,3 +171,27 @@ def test_raw_and_encrypted_data_key_from_data_key_fail(data_key_class):
         data_key_class.from_data_key(b"ahjseofij")
 
     excinfo.match(r"data_key must be type DataKey not *")
+
+
+@pytest.fixture
+def ex_result():
+    return CryptoResult(**VALID_KWARGS[CryptoResult][0])
+
+
+def test_cryptoresult_len(ex_result):
+    assert len(ex_result) == 2
+
+
+def test_cryptoresult_unpack(ex_result):
+    data, header = ex_result
+
+    assert data is ex_result.result
+    assert header is ex_result.header
+
+
+def test_cryptoresult_getitem(ex_result):
+    data = ex_result[0]
+    header = ex_result[1]
+
+    assert data is ex_result.result
+    assert header is ex_result.header

--- a/test/unit/test_structures.py
+++ b/test/unit/test_structures.py
@@ -195,3 +195,9 @@ def test_cryptoresult_getitem(ex_result):
 
     assert data is ex_result.result
     assert header is ex_result.header
+
+
+def test_cryptoresult_to_tuple(ex_result):
+    test = tuple(ex_result)
+
+    assert test == ex_result._legacy_container


### PR DESCRIPTION
*Issue #, if available:*
resolves: #223 

*Description of changes:*

After discussing #223 with @WesleyRosenblum and @acioc, we agreed that going with option 2 made the most sense and did not introduce notable risk of breaking customers. The fact that none of the tests (aside from an over-mocked unit test) needed to be changed after I changed the return values supports this conclusion.

There are two main changes introduced here, both with the aim of making the keyring trace accessible to callers:

1. The streaming classes now set a `keyring_trace` attribute as soon as they have the encryption/decryption materials.
1. The one-step APIs now return the new `CryptoResult` rather than a tuple. `CryptoResult` gives us the flexibility to add more output values in the future while also allowing unpacking and positional referencing just like the previous output (a 2-member tuple) did.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

