### PR TITLE
feat: immutable cryptographic materials (for keyrings)

### DIFF
--- a/src/aws_encryption_sdk/internal/formatting/serialize.py
+++ b/src/aws_encryption_sdk/internal/formatting/serialize.py
@@ -316,6 +316,6 @@ def serialize_wrapped_key(key_provider, wrapping_algorithm, wrapping_key_id, enc
         )
         key_ciphertext = encrypted_wrapped_key.ciphertext + encrypted_wrapped_key.tag
     return EncryptedDataKey(
-        key_provider=MasterKeyInfo(provider_id=key_provider.provider_id, key_info=key_info),
+        key_provider=MasterKeyInfo(provider_id=key_provider.provider_id, key_info=key_info, key_name=wrapping_key_id),
         encrypted_data_key=key_ciphertext,
     )

--- a/src/aws_encryption_sdk/keyrings/aws_kms/__init__.py
+++ b/src/aws_encryption_sdk/keyrings/aws_kms/__init__.py
@@ -5,7 +5,6 @@
 .. versionadded:: 1.5.0
 
 """
-import copy
 import logging
 
 import attr

--- a/src/aws_encryption_sdk/keyrings/multi.py
+++ b/src/aws_encryption_sdk/keyrings/multi.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Resources required for Multi Keyrings."""
-import copy
 import itertools
 
 import attr

--- a/src/aws_encryption_sdk/keyrings/multi.py
+++ b/src/aws_encryption_sdk/keyrings/multi.py
@@ -68,7 +68,7 @@ class MultiKeyring(Keyring):
                 "and encryption materials do not already contain a plaintext data key."
             )
 
-        new_materials = copy.copy(encryption_materials)
+        new_materials = encryption_materials
 
         # Call on_encrypt on the generator keyring if it is provided
         if self.generator is not None:
@@ -94,12 +94,13 @@ class MultiKeyring(Keyring):
         :rtype: DecryptionMaterials
         """
         # Call on_decrypt on all keyrings till decryption is successful
+        new_materials = decryption_materials
         for keyring in self._decryption_keyrings:
-            if decryption_materials.data_encryption_key is not None:
-                return decryption_materials
+            if new_materials.data_encryption_key is not None:
+                return new_materials
 
-            decryption_materials = keyring.on_decrypt(
-                decryption_materials=decryption_materials, encrypted_data_keys=encrypted_data_keys
+            new_materials = keyring.on_decrypt(
+                decryption_materials=new_materials, encrypted_data_keys=encrypted_data_keys
             )
 
-        return decryption_materials
+        return new_materials

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -42,7 +42,7 @@ def _generate_data_key(
     :param EncryptionMaterials encryption_materials: Encryption materials for the keyring to modify.
     :param MasterKeyInfo key_provider: Information about the key in the keyring.
     :rtype: EncryptionMaterials
-    :returns: Encryption materials containins data encryption key
+    :returns: Encryption materials containing a data encryption key
     """
     # Check if encryption materials contain data encryption key
     if encryption_materials.data_encryption_key is not None:

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Resources required for Raw Keyrings."""
+import copy
 import logging
 import os
 
@@ -11,7 +12,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 
-from aws_encryption_sdk.exceptions import GenerateKeyError
+from aws_encryption_sdk.exceptions import EncryptKeyError, GenerateKeyError
 from aws_encryption_sdk.identifiers import EncryptionKeyType, KeyringTraceFlag, WrappingAlgorithm
 from aws_encryption_sdk.internal.crypto.wrapping_keys import EncryptedData, WrappingKey
 from aws_encryption_sdk.internal.formatting.deserialize import deserialize_wrapped_key
@@ -35,12 +36,13 @@ def _generate_data_key(
     encryption_materials,  # type: EncryptionMaterials
     key_provider,  # type: MasterKeyInfo
 ):
-    # type: (...) -> bytes
+    # type: (...) -> EncryptionMaterials
     """Generates plaintext data key for the keyring.
 
     :param EncryptionMaterials encryption_materials: Encryption materials for the keyring to modify.
     :param MasterKeyInfo key_provider: Information about the key in the keyring.
-    :return bytes: Plaintext data key
+    :rtype: EncryptionMaterials
+    :returns: Encryption materials containins data encryption key
     """
     # Check if encryption materials contain data encryption key
     if encryption_materials.data_encryption_key is not None:
@@ -60,10 +62,9 @@ def _generate_data_key(
     # plaintext_data_key to RawDataKey
     data_encryption_key = RawDataKey(key_provider=key_provider, data_key=plaintext_data_key)
 
-    # Add generated data key to encryption_materials
-    encryption_materials.add_data_encryption_key(data_encryption_key, keyring_trace)
-
-    return plaintext_data_key
+    return encryption_materials.with_data_encryption_key(
+        data_encryption_key=data_encryption_key, keyring_trace=keyring_trace
+    )
 
 
 @attr.s
@@ -123,17 +124,20 @@ class RawAESKeyring(Keyring):
         """Generate a data key if not present and encrypt it using any available wrapping key
 
         :param EncryptionMaterials encryption_materials: Encryption materials for the keyring to modify
-        :returns: Optionally modified encryption materials
+        :returns: Encryption materials containing data key and encrypted data key
         :rtype: EncryptionMaterials
         """
-        if encryption_materials.data_encryption_key is None:
-            _generate_data_key(encryption_materials=encryption_materials, key_provider=self._key_provider)
+        new_materials = copy.copy(encryption_materials)
+
+        if new_materials.data_encryption_key is None:
+            # Get encryption materials with a new data key.
+            new_materials = _generate_data_key(encryption_materials=new_materials, key_provider=self._key_provider)
 
         try:
             # Encrypt data key
             encrypted_wrapped_key = self._wrapping_key_structure.encrypt(
-                plaintext_data_key=encryption_materials.data_encryption_key.data_key,
-                encryption_context=encryption_materials.encryption_context,
+                plaintext_data_key=new_materials.data_encryption_key.data_key,
+                encryption_context=new_materials.encryption_context,
             )
 
             # EncryptedData to EncryptedDataKey
@@ -144,18 +148,17 @@ class RawAESKeyring(Keyring):
                 encrypted_wrapped_key=encrypted_wrapped_key,
             )
         except Exception:  # pylint: disable=broad-except
-            error_message = "Raw AES Keyring unable to encrypt data key"
+            error_message = "Raw AES keyring unable to encrypt data key"
             _LOGGER.exception(error_message)
-            return encryption_materials
+            raise EncryptKeyError(error_message)
 
         # Update Keyring Trace
         keyring_trace = KeyringTrace(
-            wrapping_key=encrypted_data_key.key_provider, flags={KeyringTraceFlag.ENCRYPTED_DATA_KEY}
+            wrapping_key=self._key_provider,
+            flags={KeyringTraceFlag.ENCRYPTED_DATA_KEY, KeyringTraceFlag.SIGNED_ENCRYPTION_CONTEXT},
         )
 
-        # Add encrypted data key to encryption_materials
-        encryption_materials.add_encrypted_data_key(encrypted_data_key=encrypted_data_key, keyring_trace=keyring_trace)
-        return encryption_materials
+        return new_materials.with_encrypted_data_key(encrypted_data_key=encrypted_data_key, keyring_trace=keyring_trace)
 
     def on_decrypt(self, decryption_materials, encrypted_data_keys):
         # type: (DecryptionMaterials, Iterable[EncryptedDataKey]) -> DecryptionMaterials
@@ -163,7 +166,7 @@ class RawAESKeyring(Keyring):
 
         :param DecryptionMaterials decryption_materials: Decryption materials for the keyring to modify
         :param List[EncryptedDataKey] encrypted_data_keys: List of encrypted data keys
-        :returns: Optionally modified decryption materials
+        :returns: Decryption materials that MAY include a plaintext data key
         :rtype: DecryptionMaterials
         """
         if decryption_materials.data_encryption_key is not None:
@@ -172,9 +175,6 @@ class RawAESKeyring(Keyring):
         # Decrypt data key
         expected_key_info_len = len(self._key_info_prefix) + self._wrapping_algorithm.algorithm.iv_len
         for key in encrypted_data_keys:
-
-            if decryption_materials.data_encryption_key is not None:
-                return decryption_materials
 
             if (
                 key.key_provider.provider_id != self._key_provider.provider_id
@@ -196,16 +196,25 @@ class RawAESKeyring(Keyring):
                 )
 
             except Exception:  # pylint: disable=broad-except
+                # We intentionally WANT to catch all exceptions here
                 error_message = "Raw AES Keyring unable to decrypt data key"
                 _LOGGER.exception(error_message)
-                return decryption_materials
+                # The Raw AES keyring MUST evaluate every encrypted data key
+                # until it either succeeds or runs out of encrypted data keys.
+                continue
 
             # Create a keyring trace
-            keyring_trace = KeyringTrace(wrapping_key=self._key_provider, flags={KeyringTraceFlag.DECRYPTED_DATA_KEY})
+            keyring_trace = KeyringTrace(
+                wrapping_key=self._key_provider,
+                flags={KeyringTraceFlag.DECRYPTED_DATA_KEY, KeyringTraceFlag.VERIFIED_ENCRYPTION_CONTEXT},
+            )
 
             # Update decryption materials
             data_encryption_key = RawDataKey(key_provider=self._key_provider, data_key=plaintext_data_key)
-            decryption_materials.add_data_encryption_key(data_encryption_key, keyring_trace)
+
+            return decryption_materials.with_data_encryption_key(
+                data_encryption_key=data_encryption_key, keyring_trace=keyring_trace
+            )
 
         return decryption_materials
 
@@ -331,22 +340,24 @@ class RawRSAKeyring(Keyring):
         and encrypt it using any available wrapping key in any child keyring.
 
         :param EncryptionMaterials encryption_materials: Encryption materials for keyring to modify.
-        :returns: Optionally modified encryption materials.
+        :returns: Encryption materials containing data key and encrypted data key
         :rtype: EncryptionMaterials
         """
-        if encryption_materials.data_encryption_key is None:
-            _generate_data_key(encryption_materials=encryption_materials, key_provider=self._key_provider)
+        new_materials = copy.copy(encryption_materials)
+
+        if new_materials.data_encryption_key is None:
+            new_materials = _generate_data_key(encryption_materials=new_materials, key_provider=self._key_provider)
 
         if self._public_wrapping_key is None:
-            return encryption_materials
+            # This should be impossible, but just in case, give a useful error message.
+            raise EncryptKeyError("Raw RSA keyring unable to encrypt data key: no public key available")
 
         try:
             # Encrypt data key
             encrypted_wrapped_key = EncryptedData(
                 iv=None,
                 ciphertext=self._public_wrapping_key.encrypt(
-                    plaintext=encryption_materials.data_encryption_key.data_key,
-                    padding=self._wrapping_algorithm.padding,
+                    plaintext=new_materials.data_encryption_key.data_key, padding=self._wrapping_algorithm.padding,
                 ),
                 tag=None,
             )
@@ -359,19 +370,15 @@ class RawRSAKeyring(Keyring):
                 encrypted_wrapped_key=encrypted_wrapped_key,
             )
         except Exception:  # pylint: disable=broad-except
-            error_message = "Raw RSA Keyring unable to encrypt data key"
+            error_message = "Raw RSA keyring unable to encrypt data key"
             _LOGGER.exception(error_message)
-            return encryption_materials
+            raise EncryptKeyError(error_message)
 
         # Update Keyring Trace
-        keyring_trace = KeyringTrace(
-            wrapping_key=encrypted_data_key.key_provider, flags={KeyringTraceFlag.ENCRYPTED_DATA_KEY}
-        )
+        keyring_trace = KeyringTrace(wrapping_key=self._key_provider, flags={KeyringTraceFlag.ENCRYPTED_DATA_KEY})
 
         # Add encrypted data key to encryption_materials
-        encryption_materials.add_encrypted_data_key(encrypted_data_key=encrypted_data_key, keyring_trace=keyring_trace)
-
-        return encryption_materials
+        return new_materials.with_encrypted_data_key(encrypted_data_key=encrypted_data_key, keyring_trace=keyring_trace)
 
     def on_decrypt(self, decryption_materials, encrypted_data_keys):
         # type: (DecryptionMaterials, Iterable[EncryptedDataKey]) -> DecryptionMaterials
@@ -380,18 +387,20 @@ class RawRSAKeyring(Keyring):
         :param DecryptionMaterials decryption_materials: Decryption materials for keyring to modify.
         :param encrypted_data_keys: List of encrypted data keys.
         :type: List[EncryptedDataKey]
-        :returns: Optionally modified decryption materials.
+        :returns: Decryption materials that MAY include a plaintext data key
         :rtype: DecryptionMaterials
         """
+        if decryption_materials.data_encryption_key is not None:
+            return decryption_materials
+
         if self._private_wrapping_key is None:
             return decryption_materials
 
         # Decrypt data key
         for key in encrypted_data_keys:
-            if decryption_materials.data_encryption_key is not None:
-                return decryption_materials
             if key.key_provider != self._key_provider:
                 continue
+
             # Wrapped EncryptedDataKey to deserialized EncryptedData
             encrypted_wrapped_key = deserialize_wrapped_key(
                 wrapping_algorithm=self._wrapping_algorithm, wrapping_key_id=self.key_name, wrapped_encrypted_key=key
@@ -403,6 +412,8 @@ class RawRSAKeyring(Keyring):
             except Exception:  # pylint: disable=broad-except
                 error_message = "Raw RSA Keyring unable to decrypt data key"
                 _LOGGER.exception(error_message)
+                # The Raw RSA keyring MUST evaluate every encrypted data key
+                # until it either succeeds or runs out of encrypted data keys.
                 continue
 
             # Create a keyring trace
@@ -410,6 +421,9 @@ class RawRSAKeyring(Keyring):
 
             # Update decryption materials
             data_encryption_key = RawDataKey(key_provider=self._key_provider, data_key=plaintext_data_key)
-            decryption_materials.add_data_encryption_key(data_encryption_key, keyring_trace)
+
+            return decryption_materials.with_data_encryption_key(
+                data_encryption_key=data_encryption_key, keyring_trace=keyring_trace
+            )
 
         return decryption_materials

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Resources required for Raw Keyrings."""
-import copy
 import logging
 import os
 
@@ -345,7 +344,7 @@ class RawRSAKeyring(Keyring):
         :returns: Encryption materials containing data key and encrypted data key
         :rtype: EncryptionMaterials
         """
-        new_materials = copy.copy(encryption_materials)
+        new_materials = encryption_materials
 
         if new_materials.data_encryption_key is None:
             new_materials = _generate_data_key(encryption_materials=new_materials, key_provider=self._key_provider)

--- a/src/aws_encryption_sdk/materials_managers/__init__.py
+++ b/src/aws_encryption_sdk/materials_managers/__init__.py
@@ -170,8 +170,10 @@ class CryptographicMaterials(object):
         new_materials = copy.copy(self)
 
         data_key = _data_key_to_raw_data_key(data_key=data_encryption_key)
-        new_materials._setattr("data_encryption_key", data_key)
-        new_materials._keyring_trace.append(keyring_trace)
+        new_materials._setattr(  # simplify access to copies pylint: disable=protected-access
+            "data_encryption_key", data_key
+        )
+        new_materials._keyring_trace.append(keyring_trace)  # simplify access to copies pylint: disable=protected-access
 
         return new_materials
 
@@ -336,8 +338,10 @@ class EncryptionMaterials(CryptographicMaterials):
 
         new_materials = copy.copy(self)
 
-        new_materials._encrypted_data_keys.append(encrypted_data_key)
-        new_materials._keyring_trace.append(keyring_trace)
+        new_materials._encrypted_data_keys.append(  # simplify access to copies pylint: disable=protected-access
+            encrypted_data_key
+        )
+        new_materials._keyring_trace.append(keyring_trace)  # simplify access to copies pylint: disable=protected-access
         return new_materials
 
     def with_signing_key(self, signing_key):
@@ -362,7 +366,7 @@ class EncryptionMaterials(CryptographicMaterials):
         # Verify that the signing key matches the algorithm
         Signer.from_key_bytes(algorithm=new_materials.algorithm, key_bytes=signing_key)
 
-        new_materials._setattr("signing_key", signing_key)
+        new_materials._setattr("signing_key", signing_key)  # simplify access to copies pylint: disable=protected-access
 
         return new_materials
 
@@ -517,6 +521,8 @@ class DecryptionMaterials(CryptographicMaterials):
         # Verify that the verification key matches the algorithm
         Verifier.from_key_bytes(algorithm=new_materials.algorithm, key_bytes=verification_key)
 
-        new_materials._setattr("verification_key", verification_key)
+        new_materials._setattr(  # simplify access to copies pylint: disable=protected-access
+            "verification_key", verification_key
+        )
 
         return new_materials

--- a/test/functional/keyrings/aws_kms/test_aws_kms.py
+++ b/test/functional/keyrings/aws_kms/test_aws_kms.py
@@ -79,6 +79,7 @@ def test_aws_kms_single_cmk_keyring_on_encrypt_existing_data_key(fake_generator)
 
     result_materials = keyring.on_encrypt(initial_materials)
 
+    assert result_materials is not initial_materials
     assert result_materials.data_encryption_key is not None
     assert len(result_materials.encrypted_data_keys) == 1
 
@@ -149,6 +150,7 @@ def test_aws_kms_single_cmk_keyring_on_decrypt_single_cmk(fake_generator):
         decryption_materials=initial_decryption_materials, encrypted_data_keys=encryption_materials.encrypted_data_keys
     )
 
+    assert result_materials is not initial_decryption_materials
     assert result_materials.data_encryption_key is not None
 
     generator_flags = _matching_flags(
@@ -243,6 +245,7 @@ def test_aws_kms_discovery_keyring_on_encrypt():
 
     result_materials = keyring.on_encrypt(initial_materials)
 
+    assert result_materials is initial_materials
     assert len(result_materials.encrypted_data_keys) == 0
 
 
@@ -268,6 +271,7 @@ def test_aws_kms_discovery_keyring_on_decrypt(encryption_materials_for_discovery
         decryption_materials=initial_decryption_materials, encrypted_data_keys=encryption_materials.encrypted_data_keys
     )
 
+    assert result_materials is not initial_decryption_materials
     assert result_materials.data_encryption_key is not None
 
     generator_flags = _matching_flags(

--- a/test/unit/internal/formatting/test_serialize.py
+++ b/test/unit/internal/formatting/test_serialize.py
@@ -325,7 +325,9 @@ class TestSerialize(object):
         )
         assert test == EncryptedDataKey(
             key_provider=MasterKeyInfo(
-                provider_id=VALUES["provider_id"], key_info=VALUES["wrapped_keys"]["serialized"]["key_info"]
+                provider_id=self.mock_key_provider.provider_id,
+                key_info=VALUES["wrapped_keys"]["serialized"]["key_info"],
+                key_name=VALUES["wrapped_keys"]["raw"]["key_info"],
             ),
             encrypted_data_key=VALUES["wrapped_keys"]["serialized"]["key_ciphertext"],
         )

--- a/test/unit/keyrings/test_multi.py
+++ b/test/unit/keyrings/test_multi.py
@@ -215,7 +215,7 @@ def test_on_decrypt_when_data_encryption_key_given(mock_generator, mock_child_1,
     initial_materials = get_decryption_materials_with_data_key()
     new_materials = test_multi_keyring.on_decrypt(decryption_materials=initial_materials, encrypted_data_keys=[])
 
-    assert new_materials is not initial_materials
+    assert new_materials is initial_materials
 
     for keyring in test_multi_keyring._decryption_keyrings:
         assert not keyring.on_decrypt.called
@@ -246,9 +246,10 @@ def test_no_keyring_called_after_data_encryption_key_added_when_data_encryption_
     )
 
     test_multi_keyring = MultiKeyring(generator=mock_generator, children=[mock_child_3, mock_child_1, mock_child_2])
-    test_multi_keyring.on_decrypt(
-        decryption_materials=get_decryption_materials_without_data_key(), encrypted_data_keys=[]
-    )
+    initial_materials = get_decryption_materials_without_data_key()
+    new_materials = test_multi_keyring.on_decrypt(decryption_materials=initial_materials, encrypted_data_keys=[])
+
+    assert new_materials is not initial_materials
     assert mock_generator.on_decrypt.called
     assert mock_child_3.on_decrypt.called
     assert not mock_child_1.called

--- a/test/unit/keyrings/test_multi.py
+++ b/test/unit/keyrings/test_multi.py
@@ -187,7 +187,11 @@ def test_number_of_encrypted_data_keys_with_generator_and_children():
 
 def test_on_encrypt_when_data_encryption_key_given(mock_generator, mock_child_1, mock_child_2):
     test_multi_keyring = MultiKeyring(generator=mock_generator, children=[mock_child_1, mock_child_2])
-    test_multi_keyring.on_encrypt(encryption_materials=get_encryption_materials_with_data_key())
+    initial_materials = get_encryption_materials_with_data_key()
+    new_materials = test_multi_keyring.on_encrypt(encryption_materials=initial_materials)
+
+    assert new_materials is not initial_materials
+
     for keyring in test_multi_keyring._decryption_keyrings:
         keyring.on_encrypt.assert_called_once()
 
@@ -208,7 +212,11 @@ def test_on_encrypt_edk_length_when_keyring_generates_but_does_not_encrypt_encry
 
 def test_on_decrypt_when_data_encryption_key_given(mock_generator, mock_child_1, mock_child_2):
     test_multi_keyring = MultiKeyring(generator=mock_generator, children=[mock_child_1, mock_child_2])
-    test_multi_keyring.on_decrypt(decryption_materials=get_decryption_materials_with_data_key(), encrypted_data_keys=[])
+    initial_materials = get_decryption_materials_with_data_key()
+    new_materials = test_multi_keyring.on_decrypt(decryption_materials=initial_materials, encrypted_data_keys=[])
+
+    assert new_materials is not initial_materials
+
     for keyring in test_multi_keyring._decryption_keyrings:
         assert not keyring.on_decrypt.called
 

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -33,6 +33,7 @@ except ImportError:  # pragma: no cover
 
 _ENCRYPTION_CONTEXT = {"encryption": "context", "values": "here"}
 _PROVIDER_ID = "Random Raw Keys"
+_EXISTING_KEY_ID = b"pre-seeded key id"
 _KEY_ID = b"5325b043-5843-4629-869c-64794af77ada"
 _WRAPPING_KEY = b"\xeby-\x80A6\x15rA8\x83#,\xe4\xab\xac`\xaf\x99Z\xc1\xce\xdb\xb6\x0f\xb7\x805\xb2\x14J3"
 _SIGNING_KEY = b"aws-crypto-public-key"
@@ -98,7 +99,7 @@ class OnlyGenerateKeyring(Keyring):
             data_encryption_key = RawDataKey(
                 key_provider=key_provider, data_key=os.urandom(encryption_materials.algorithm.kdf_input_len)
             )
-            encryption_materials.add_data_encryption_key(
+            encryption_materials = encryption_materials.with_data_encryption_key(
                 data_encryption_key=data_encryption_key,
                 keyring_trace=KeyringTrace(wrapping_key=key_provider, flags={KeyringTraceFlag.GENERATED_DATA_KEY}),
             )
@@ -113,14 +114,14 @@ def get_encryption_materials_with_data_key():
     return EncryptionMaterials(
         algorithm=AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
         data_encryption_key=RawDataKey(
-            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_KEY_ID),
+            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
             data_key=b'*!\xa1"^-(\xf3\x105\x05i@B\xc2\xa2\xb7\xdd\xd5\xd5\xa9\xddm\xfae\xa8\\$\xf9d\x1e(',
         ),
         encryption_context=_ENCRYPTION_CONTEXT,
         signing_key=_SIGNING_KEY,
         keyring_trace=[
             KeyringTrace(
-                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_KEY_ID),
+                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
                 flags={KeyringTraceFlag.GENERATED_DATA_KEY},
             )
         ],
@@ -131,14 +132,14 @@ def get_encryption_materials_with_data_encryption_key():
     return EncryptionMaterials(
         algorithm=AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
         data_encryption_key=RawDataKey(
-            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=b"5430b043-5843-4629-869c-64794af77ada"),
+            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
             data_key=b'*!\xa1"^-(\xf3\x105\x05i@B\xc2\xa2\xb7\xdd\xd5\xd5\xa9\xddm\xfae\xa8\\$\xf9d\x1e(',
         ),
         encryption_context=_ENCRYPTION_CONTEXT,
         signing_key=_SIGNING_KEY,
         keyring_trace=[
             KeyringTrace(
-                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=b"5430b043-5843-4629-869c-64794af77ada"),
+                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
                 flags={KeyringTraceFlag.GENERATED_DATA_KEY},
             )
         ],
@@ -157,12 +158,12 @@ def get_encryption_materials_with_encrypted_data_key():
     return EncryptionMaterials(
         algorithm=AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
         data_encryption_key=RawDataKey(
-            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_KEY_ID),
+            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
             data_key=b'*!\xa1"^-(\xf3\x105\x05i@B\xc2\xa2\xb7\xdd\xd5\xd5\xa9\xddm\xfae\xa8\\$\xf9d\x1e(',
         ),
         encrypted_data_keys=[
             EncryptedDataKey(
-                key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_KEY_ID),
+                key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
                 encrypted_data_key=b"\xde^\x97\x7f\x84\xe9\x9e\x98\xd0\xe2\xf8\xd5\xcb\xe9\x7f.}\x87\x16,\x11n#\xc8p"
                 b"\xdb\xbf\x94\x86*Q\x06\xd2\xf5\xdah\x08\xa4p\x81\xf7\xf4G\x07FzE\xde",
             )
@@ -171,7 +172,7 @@ def get_encryption_materials_with_encrypted_data_key():
         signing_key=_SIGNING_KEY,
         keyring_trace=[
             KeyringTrace(
-                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_KEY_ID),
+                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
                 flags={KeyringTraceFlag.GENERATED_DATA_KEY, KeyringTraceFlag.ENCRYPTED_DATA_KEY},
             )
         ],
@@ -182,7 +183,7 @@ def get_encryption_materials_with_encrypted_data_key_aes():
     return EncryptionMaterials(
         algorithm=AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
         data_encryption_key=RawDataKey(
-            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_KEY_ID),
+            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
             data_key=b'*!\xa1"^-(\xf3\x105\x05i@B\xc2\xa2\xb7\xdd\xd5\xd5\xa9\xddm\xfae\xa8\\$\xf9d\x1e(',
         ),
         encrypted_data_keys=[_ENCRYPTED_DATA_KEY_AES],
@@ -190,7 +191,7 @@ def get_encryption_materials_with_encrypted_data_key_aes():
         signing_key=_SIGNING_KEY,
         keyring_trace=[
             KeyringTrace(
-                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_KEY_ID),
+                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
                 flags={KeyringTraceFlag.GENERATED_DATA_KEY, KeyringTraceFlag.ENCRYPTED_DATA_KEY},
             )
         ],
@@ -217,14 +218,14 @@ def get_decryption_materials_with_data_key():
     return DecryptionMaterials(
         algorithm=AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
         data_encryption_key=RawDataKey(
-            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_KEY_ID),
+            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
             data_key=b'*!\xa1"^-(\xf3\x105\x05i@B\xc2\xa2\xb7\xdd\xd5\xd5\xa9\xddm\xfae\xa8\\$\xf9d\x1e(',
         ),
         encryption_context=_ENCRYPTION_CONTEXT,
         verification_key=b"ex_verification_key",
         keyring_trace=[
             KeyringTrace(
-                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_KEY_ID),
+                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
                 flags={KeyringTraceFlag.DECRYPTED_DATA_KEY},
             )
         ],
@@ -235,14 +236,14 @@ def get_decryption_materials_with_data_encryption_key():
     return DecryptionMaterials(
         algorithm=AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
         data_encryption_key=RawDataKey(
-            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=b"5430b043-5843-4629-869c-64794af77ada"),
+            key_provider=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
             data_key=b'*!\xa1"^-(\xf3\x105\x05i@B\xc2\xa2\xb7\xdd\xd5\xd5\xa9\xddm\xfae\xa8\\$\xf9d\x1e(',
         ),
         encryption_context=_ENCRYPTION_CONTEXT,
         verification_key=b"ex_verification_key",
         keyring_trace=[
             KeyringTrace(
-                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=b"5430b043-5843-4629-869c-64794af77ada"),
+                wrapping_key=MasterKeyInfo(provider_id=_PROVIDER_ID, key_info=_EXISTING_KEY_ID),
                 flags={KeyringTraceFlag.DECRYPTED_DATA_KEY},
             )
         ],


### PR DESCRIPTION
*Issue #, if available:*

* resolves: #214 
* https://github.com/awslabs/aws-encryption-sdk-specification/issues/32

*Description of changes:*

The primary focus of this change is to move keyrings to immutable cryptographic materials. Rather than providing APIs that let you modify materials, we now provide APIs that let you get a new copy of those materials that also include additional contents.

While I was working on that, I found a few other points where the keyrings were not compliant with the spec, particularly around behavior when failing on encrypt and decrypt, and in the specific values set in the keyring trace. Looking back through the changes, I would have a hard time extracting any single piece, so unfortunately they're all just getting lumped into this one PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

