### PR TITLE
feat: deprecate master key providers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,9 @@ Deprecations
 
 * Deprecate master key providers in favor of keyrings.
 
-    * We do not have a planned version for when we will remove master key providers.
-      If that changes, we will communicate that as defined in our versioning policy.
+    * We still support using master key providers and are not removing them yet.
+      When we decide to remove them,
+      we will communicate that as defined in our versioning policy.
 
 * Deprecate support for Python 3.4.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Major Features
 
 * Add `keyrings`_.
 * Change one-step APIs to return a :class:`CryptoResult` rather than a tuple.
+
     * Modified APIs: ``aws_encryption_sdk.encrypt`` and ``aws_encryption_sdk.decrypt``.
 
 .. note::
@@ -20,6 +21,18 @@ Major Features
     so this change should not break any existing consumers
     unless you are specifically relying on the output being an instance of :class:`tuple`.
 
+Deprecations
+------------
+
+* Deprecate master key providers in favor of keyrings.
+
+    * We do not have a planned version for when we will remove master key providers.
+      If that changes, we will communicate that as defined in our versioning policy.
+
+* Deprecate support for Python 3.4.
+
+    * This does not mean that this library will no longer work or install with 3.4,
+      but we are no longer testing against or advertising support 3.4.
 
 1.4.1 -- 2019-09-20
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,7 @@ Deprecations
 * Deprecate support for Python 3.4.
 
     * This does not mean that this library will no longer work or install with 3.4,
-      but we are no longer testing against or advertising support 3.4.
+      but we are no longer testing against or advertising support for 3.4.
 
 1.4.1 -- 2019-09-20
 ===================

--- a/README.rst
+++ b/README.rst
@@ -63,31 +63,28 @@ Cryptographic Materials Managers
 --------------------------------
 The cryptographic materials manager (CMM) assembles the cryptographic materials
 that are used to encrypt and decrypt data.
-The cryptographic materials include plaintext and encrypted data keys, and an optional message signing key.
-You can use the default CMM that the AWS Encryption SDK provides or write a custom CMM.
-You can specify a CMM, but you never interact with it directly.
-The encryption and decryption methods handle it for you.
 
-The default CMM gets the encryption or decryption materials from
-the keyring or master key provider that you specify.
-This might involve a call to a cryptographic service, such as AWS Key Management Service (AWS KMS).
-
-You can specify a CMM and master key provider or keyring, but it's not required.
-If you specify a master key provider or keyring, the AWS Encryption SDK creates a Default CMM for you.
+`For more details,
+see the AWS Encryption SDK developer guide cryptographic materials manager concept.
+<https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html#crypt-materials-manager>`_
 
 Keyrings
 --------
 
 A keyring generates, encrypts, and decrypts data keys.
-Each keyring is typically associated with a wrapping key or a service that provides and protects wrapping keys.
-You can use the keyrings that the AWS Encryption SDK provides or write your own compatible custom keyrings.
+
+`For more details,
+see the AWS Encryption SDK developer guide keyring concept.
+<https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html#keyring>`_
 
 Data Keys
 ---------
 
 A data key is an encryption key that the AWS Encryption SDK uses to encrypt your data.
-Each data key is a byte array that conforms to the requirements for cryptographic keys.
-Unless you're using data key caching, the AWS Encryption SDK uses a unique data key to encrypt each message.
+
+`For more details,
+see the AWS Encryption SDK developer guide data key concept.
+<https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html#DEK>`_
 
 *****
 Usage

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,9 @@ Installation
 
 Concepts
 ========
-There are three main concepts that are helpful to understand when using the AWS Encryption SDK:
+There are three main concepts that are helpful to understand when using the AWS Encryption SDK.
+
+For further information, see the `AWS Encryption SDK developer guide concepts`_.
 
 Cryptographic Materials Managers
 --------------------------------
@@ -103,6 +105,8 @@ to your use-case in order to obtain peak performance.
 
 
 .. _AWS Encryption SDK: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/introduction.html
+.. _AWS Encryption SDK developer guide concepts:
+    https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html
 .. _cryptography: https://cryptography.io/en/latest/
 .. _cryptography installation guide: https://cryptography.io/en/latest/installation/
 .. _Read the Docs: http://aws-encryption-sdk-python.readthedocs.io/en/latest/

--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -39,14 +39,15 @@ def encrypt(**kwargs):
     .. code:: python
 
         >>> import aws_encryption_sdk
-        >>> kms_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(key_ids=[
-        ...     'arn:aws:kms:us-east-1:2222222222222:key/22222222-2222-2222-2222-222222222222',
-        ...     'arn:aws:kms:us-east-1:3333333333333:key/33333333-3333-3333-3333-333333333333'
-        ... ])
+        >>> from aws_encryption_sdk.keyrings.aws_kms import KmsKeyring
+        >>> keyring = KmsKeyring(
+        ...     generator_key_id="arn:aws:kms:us-east-1:2222222222222:key/22222222-2222-2222-2222-222222222222",
+        ...     key_ids=["arn:aws:kms:us-east-1:3333333333333:key/33333333-3333-3333-3333-333333333333"],
+        ... )
         >>> my_ciphertext, encryptor_header = aws_encryption_sdk.encrypt(
         ...     source=my_plaintext,
-        ...     key_provider=kms_key_provider
-        ... )
+        ...     keyring=keyring,
+        >>> )
 
     :param config: Client configuration object (config or individual parameters required)
     :type config: aws_encryption_sdk.streaming_client.EncryptorConfig
@@ -106,13 +107,14 @@ def decrypt(**kwargs):
     .. code:: python
 
         >>> import aws_encryption_sdk
-        >>> kms_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(key_ids=[
-        ...     'arn:aws:kms:us-east-1:2222222222222:key/22222222-2222-2222-2222-222222222222',
-        ...     'arn:aws:kms:us-east-1:3333333333333:key/33333333-3333-3333-3333-333333333333'
-        ... ])
-        >>> my_ciphertext, encryptor_header = aws_encryption_sdk.decrypt(
+        >>> from aws_encryption_sdk.keyrings.aws_kms import KmsKeyring
+        >>> keyring = KmsKeyring(
+        ...     generator_key_id="arn:aws:kms:us-east-1:2222222222222:key/22222222-2222-2222-2222-222222222222",
+        ...     key_ids=["arn:aws:kms:us-east-1:3333333333333:key/33333333-3333-3333-3333-333333333333"],
+        ... )
+        >>> my_ciphertext, decryptor_header = aws_encryption_sdk.decrypt(
         ...     source=my_ciphertext,
-        ...     key_provider=kms_key_provider
+        ...     keyring=keyring,
         ... )
 
     :param config: Client configuration object (config or individual parameters required)
@@ -164,17 +166,18 @@ def stream(**kwargs):
     .. code:: python
 
         >>> import aws_encryption_sdk
-        >>> kms_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(key_ids=[
-        ...     'arn:aws:kms:us-east-1:2222222222222:key/22222222-2222-2222-2222-222222222222',
-        ...     'arn:aws:kms:us-east-1:3333333333333:key/33333333-3333-3333-3333-333333333333'
-        ...  ])
+        >>> from aws_encryption_sdk.keyrings.aws_kms import KmsKeyring
+        >>> keyring = KmsKeyring(
+        ...     generator_key_id="arn:aws:kms:us-east-1:2222222222222:key/22222222-2222-2222-2222-222222222222",
+        ...     key_ids=["arn:aws:kms:us-east-1:3333333333333:key/33333333-3333-3333-3333-333333333333"],
+        ... )
         >>> plaintext_filename = 'my-secret-data.dat'
         >>> ciphertext_filename = 'my-encrypted-data.ct'
         >>> with open(plaintext_filename, 'rb') as pt_file, open(ciphertext_filename, 'wb') as ct_file:
         ...      with aws_encryption_sdk.stream(
         ...         mode='e',
         ...         source=pt_file,
-        ...         key_provider=kms_key_provider
+        ...         keyring=keyring,
         ...     ) as encryptor:
         ...         for chunk in encryptor:
         ...              ct_file.write(chunk)
@@ -183,7 +186,7 @@ def stream(**kwargs):
         ...     with aws_encryption_sdk.stream(
         ...         mode='d',
         ...         source=ct_file,
-        ...         key_provider=kms_key_provider
+        ...         keyring=keyring,
         ...     ) as decryptor:
         ...         for chunk in decryptor:
         ...             pt_file.write(chunk)

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -86,6 +86,9 @@ class MasterKeyProvider(object):
         # DeprecationWarning are ignored by default,
         # but because we do not have a plan to remove master key providers,
         # I think this is the correct level of visibility.
+        #
+        # Once we decide that we are one X or Y version away from removing master key providers,
+        # we should upgrade this to a UserWarning.
         warnings.warn(
             "Master key providers are deprecated as of 1.5.0. You should migrate to keyrings.", DeprecationWarning
         )

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -13,6 +13,7 @@
 """Base class interface for Master Key Providers."""
 import abc
 import logging
+import warnings
 
 import attr
 import six
@@ -78,6 +79,14 @@ class MasterKeyProvider(object):
         """Set key index and member set for all new instances here
         to avoid requiring child classes to call super init.
         """
+        # DeprecationWarning are ignored by default,
+        # but because we do not have a plan to remove master key providers,
+        # I think this is the correct level of visibility.
+        warnings.warn(
+            "Master key providers are deprecated as of 1.5.0. You should migrate to keyrings.",
+            DeprecationWarning
+        )
+
         instance = super(MasterKeyProvider, cls).__new__(cls)
         config = kwargs.pop("config", None)
         if not isinstance(config, instance._config_class):  # pylint: disable=protected-access

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -84,7 +84,7 @@ class MasterKeyProvider(object):
         to avoid requiring child classes to call super init.
         """
         # DeprecationWarning are ignored by default,
-        # but because we do not have a plan to remove master key providers,
+        # but because we are not yet removing master key providers,
         # I think this is the correct level of visibility.
         #
         # Once we decide that we are one X or Y version away from removing master key providers,

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -52,6 +52,10 @@ class MasterKeyProviderConfig(object):
 class MasterKeyProvider(object):
     """Parent interface for Master Key Provider classes.
 
+    .. versionadded:: 1.5.0
+        Master key providers are deprecated.
+        Use :class:`aws_encryption_sdk.keyrings.base.Keyring` instead.
+
     :param config: Configuration object
     :type config: aws_encryption_sdk.key_providers.base.MasterKeyProviderConfig
     """
@@ -83,8 +87,7 @@ class MasterKeyProvider(object):
         # but because we do not have a plan to remove master key providers,
         # I think this is the correct level of visibility.
         warnings.warn(
-            "Master key providers are deprecated as of 1.5.0. You should migrate to keyrings.",
-            DeprecationWarning
+            "Master key providers are deprecated as of 1.5.0. You should migrate to keyrings.", DeprecationWarning
         )
 
         instance = super(MasterKeyProvider, cls).__new__(cls)
@@ -337,6 +340,10 @@ class MasterKeyConfig(object):
 @six.add_metaclass(abc.ABCMeta)
 class MasterKey(MasterKeyProvider):
     """Parent interface for Master Key classes.
+
+    .. versionadded:: 1.5.0
+        Master key providers are deprecated.
+        Use :class:`aws_encryption_sdk.keyrings.base.Keyring` instead.
 
     :param bytes key_id: Key ID for Master Key
     :param config: Configuration object

--- a/src/aws_encryption_sdk/key_providers/kms.py
+++ b/src/aws_encryption_sdk/key_providers/kms.py
@@ -78,6 +78,10 @@ class KMSMasterKeyProviderConfig(MasterKeyProviderConfig):
 class KMSMasterKeyProvider(MasterKeyProvider):
     """Master Key Provider for KMS.
 
+    .. versionadded:: 1.5.0
+        Master key providers are deprecated.
+        Use :class:`aws_encryption_sdk.keyrings.aws_kms.KmsKeyring` instead.
+
     >>> import aws_encryption_sdk
     >>> kms_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(key_ids=[
     ...     'arn:aws:kms:us-east-1:2222222222222:key/22222222-2222-2222-2222-222222222222',
@@ -225,6 +229,10 @@ class KMSMasterKeyConfig(MasterKeyConfig):
 
 class KMSMasterKey(MasterKey):
     """Master Key class for KMS CMKs.
+
+    .. versionadded:: 1.5.0
+        Master key providers are deprecated.
+        Use :class:`aws_encryption_sdk.keyrings.aws_kms.KmsKeyring` instead.
 
     :param config: Configuration object (config or individual parameters required)
     :type config: aws_encryption_sdk.key_providers.kms.KMSMasterKeyConfig

--- a/src/aws_encryption_sdk/key_providers/raw.py
+++ b/src/aws_encryption_sdk/key_providers/raw.py
@@ -49,6 +49,11 @@ class RawMasterKeyConfig(MasterKeyConfig):
 class RawMasterKey(MasterKey):
     """Raw Master Key.
 
+    .. versionadded:: 1.5.0
+        Master key providers are deprecated.
+        Use :class:`aws_encryption_sdk.keyrings.raw.RawAESKeyring`
+        or :class:`aws_encryption_sdk.keyrings.raw.RawRSAKeyring` instead.
+
     :param config: Configuration object (config or individual parameters required)
     :type config: aws_encryption_sdk.key_providers.raw.RawMasterKeyConfig
     :param bytes key_id: Key ID for Master Key
@@ -191,6 +196,11 @@ class RawMasterKey(MasterKey):
 @six.add_metaclass(abc.ABCMeta)
 class RawMasterKeyProvider(MasterKeyProvider):
     """Raw Master Key Provider.
+
+    .. versionadded:: 1.5.0
+        Master key providers are deprecated.
+        Use :class:`aws_encryption_sdk.keyrings.raw.RawAESKeyring`
+        or :class:`aws_encryption_sdk.keyrings.raw.RawRSAKeyring` instead.
 
     :param config: Configuration object (optional)
     :type config: aws_encryption_sdk.key_providers.base.MasterKeyProviderConfig

--- a/test/unit/key_providers/base/test_base_master_key_provider.py
+++ b/test/unit/key_providers/base/test_base_master_key_provider.py
@@ -60,6 +60,12 @@ def test_repr():
     )
 
 
+def test_deprecated():
+
+    with pytest.warns(DeprecationWarning):
+        MockMasterKeyProvider(provider_id="ex_provider_id", mock_new_master_key="ex_new_master_key")
+
+
 class TestBaseMasterKeyProvider(object):
     def test_provider_id_enforcement(self):
         class TestProvider(MasterKeyProvider):


### PR DESCRIPTION
*Issue #, if available:*
resolves: #238 

*Description of changes:*
I went with `DeprecationWarning` even though it is ignored by default because we do not have any plans for when we will actually remove master key providers. When that changes, we should up that to a `UserWarning` and communicate the upcoming removal as defined in our versioning policy.

https://docs.python.org/3/library/warnings.html#warning-categories

In addition to adding deprecation notices, this also removes any use of master key providers from inline examples. For the readme I decided to just remove all of the inline examples because we have a much more comprehensive set of examples in the examples directory now. The new concepts descriptions in the readme are taken from developer guide's concepts section.

https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

