### PR TITLE
chore: disable the test vector handler tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci_test-vector-handler.yaml
+++ b/.github/workflows/ci_test-vector-handler.yaml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   tests:
-    # Until we address the credentials problem,
-    # do not run for pull requests.
-    if: github.event != 'pull_request'
+    # Leaving this defined but disabled
+    # until we address the credentials problem.
+    if: 1 == 0
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true


### PR DESCRIPTION
*Description of changes:*

I had been attempting to have the test vector handler tests only run on push and scheduled events, but that doesn't appear to have been working as expected. For now, this will just completely disable those tests. This is a housekeeping effort to avoid the current state where every PR has ~57 checks that are expected to fail.

Three of the static analysis checks are still expected to fail, but I think that handling those is more manageable and IMO it is better to let them keep failing until we can clean that up than to disable them. Having them fail reminds us that we need to fix them.

NOTE: These tests are still running as part of the Travis suite. We cannot run them in GitHub Actions until we figure out a solution to getting AWS credentials into GitHub Actions on pull requests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

