### PR TITLE
docs: fix security issue notifications link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,4 +117,4 @@ to your use-case in order to obtain peak performance.
 .. _final message: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/message-format.html
 .. _encryption context: https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context
 .. _examples: https://github.com/aws/aws-encryption-sdk-python/tree/master/examples
-.. _Security issue notifications: ./CONTRIBUTING.md#security-issue-notifications
+.. _Security issue notifications: https://github.com/aws/aws-encryption-sdk-python/tree/master//CONTRIBUTING.md#security-issue-notifications

--- a/README.rst
+++ b/README.rst
@@ -117,4 +117,4 @@ to your use-case in order to obtain peak performance.
 .. _final message: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/message-format.html
 .. _encryption context: https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context
 .. _examples: https://github.com/aws/aws-encryption-sdk-python/tree/master/examples
-.. _Security issue notifications: https://github.com/aws/aws-encryption-sdk-python/tree/master//CONTRIBUTING.md#security-issue-notifications
+.. _Security issue notifications: https://github.com/aws/aws-encryption-sdk-python/tree/master/CONTRIBUTING.md#security-issue-notifications


### PR DESCRIPTION
*Description of changes:*

The relative link worked when viewing the readme on GitHub, but didn't work in the sphinx-rendered docs.

https://aws-encryption-sdk-python.readthedocs.io/en/keyring/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

