### PR TITLE
fix: move calls requiring integ test environment setup from test setup to inside test body

### DIFF
--- a/test/integration/test_client.py
+++ b/test/integration/test_client.py
@@ -43,7 +43,7 @@ def _generate_mkp():
 def test_encrypt_verify_user_agent_in_logs(caplog, parameter_name, value_partial):
     caplog.set_level(level=logging.DEBUG)
 
-    aws_encryption_sdk.encrypt(source=VALUES["plaintext_128"], parameter_name=value_partial())
+    aws_encryption_sdk.encrypt(source=VALUES["plaintext_128"], **{parameter_name: value_partial()})
 
     assert USER_AGENT_SUFFIX in caplog.text
 
@@ -93,10 +93,10 @@ def test_encrypt_decrypt_cycle_aws_kms(
         encryption_context=encryption_context,
         frame_length=frame_size,
         algorithm=algorithm_suite,
-        encrypt_key_provider_param=encrypt_key_provider_partial(),
+        **{encrypt_key_provider_param: encrypt_key_provider_partial()}
     )
     decrypted, _ = aws_encryption_sdk.decrypt(
-        source=ciphertext, decrypt_key_provider_param=decrypt_key_provider_partial()
+        source=ciphertext, **{decrypt_key_provider_param: decrypt_key_provider_partial()}
     )
     assert decrypted == plaintext
 

--- a/test/integration/test_client.py
+++ b/test/integration/test_client.py
@@ -27,20 +27,23 @@ VALUES = {
 }
 
 
+def _generate_mkp():
+    """Isolated inside a function to avoid calling get_cmk_arn during test discovery."""
+    return setup_kms_master_key_provider().master_key(get_cmk_arn())
+
+
 @pytest.mark.parametrize(
-    "kwargs",
+    "parameter_name, value_partial",
     (
-        pytest.param(dict(key_provider=setup_kms_master_key_provider()), id="AWS KMS master key provider"),
-        pytest.param(
-            dict(key_provider=setup_kms_master_key_provider().master_key(get_cmk_arn())), id="AWS KMS master key"
-        ),
-        pytest.param(dict(keyring=build_aws_kms_keyring()), id="AWS KMS keyring"),
+        pytest.param("key_provider", setup_kms_master_key_provider, id="AWS KMS master key provider"),
+        pytest.param("key_provider", _generate_mkp, id="AWS KMS master key"),
+        pytest.param("keyring", build_aws_kms_keyring, id="AWS KMS keyring"),
     ),
 )
-def test_encrypt_verify_user_agent_in_logs(caplog, kwargs):
+def test_encrypt_verify_user_agent_in_logs(caplog, parameter_name, value_partial):
     caplog.set_level(level=logging.DEBUG)
 
-    aws_encryption_sdk.encrypt(source=VALUES["plaintext_128"], **kwargs)
+    aws_encryption_sdk.encrypt(source=VALUES["plaintext_128"], parameter_name=value_partial())
 
     assert USER_AGENT_SUFFIX in caplog.text
 
@@ -48,17 +51,17 @@ def test_encrypt_verify_user_agent_in_logs(caplog, kwargs):
 @pytest.mark.parametrize("frame_size", (pytest.param(0, id="unframed"), pytest.param(1024, id="1024 byte frame")))
 @pytest.mark.parametrize("algorithm_suite", Algorithm)
 @pytest.mark.parametrize(
-    "encrypt_key_provider_kwargs",
+    "encrypt_key_provider_param, encrypt_key_provider_partial",
     (
-        pytest.param(dict(key_provider=setup_kms_master_key_provider()), id="encrypt with MKP"),
-        pytest.param(dict(keyring=build_aws_kms_keyring()), id="encrypt with keyring"),
+        pytest.param("key_provider", setup_kms_master_key_provider, id="encrypt with MKP"),
+        pytest.param("keyring", build_aws_kms_keyring, id="encrypt with keyring"),
     ),
 )
 @pytest.mark.parametrize(
-    "decrypt_key_provider_kwargs",
+    "decrypt_key_provider_param, decrypt_key_provider_partial",
     (
-        pytest.param(dict(key_provider=setup_kms_master_key_provider()), id="decrypt with MKP"),
-        pytest.param(dict(keyring=build_aws_kms_keyring()), id="decrypt with keyring"),
+        pytest.param("key_provider", setup_kms_master_key_provider, id="decrypt with MKP"),
+        pytest.param("keyring", build_aws_kms_keyring, id="decrypt with keyring"),
     ),
 )
 @pytest.mark.parametrize(
@@ -76,16 +79,25 @@ def test_encrypt_verify_user_agent_in_logs(caplog, kwargs):
     ),
 )
 def test_encrypt_decrypt_cycle_aws_kms(
-    frame_size, algorithm_suite, encrypt_key_provider_kwargs, decrypt_key_provider_kwargs, encryption_context, plaintext
+    frame_size,
+    algorithm_suite,
+    encrypt_key_provider_param,
+    encrypt_key_provider_partial,
+    decrypt_key_provider_param,
+    decrypt_key_provider_partial,
+    encryption_context,
+    plaintext,
 ):
     ciphertext, _ = aws_encryption_sdk.encrypt(
         source=plaintext,
         encryption_context=encryption_context,
         frame_length=frame_size,
         algorithm=algorithm_suite,
-        **encrypt_key_provider_kwargs
+        encrypt_key_provider_param=encrypt_key_provider_partial(),
     )
-    decrypted, _ = aws_encryption_sdk.decrypt(source=ciphertext, **decrypt_key_provider_kwargs)
+    decrypted, _ = aws_encryption_sdk.decrypt(
+        source=ciphertext, decrypt_key_provider_param=decrypt_key_provider_partial()
+    )
     assert decrypted == plaintext
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,11 @@ commands =
 [testenv:nocmk]
 basepython = python3
 sitepackages = False
+#########################################################
+# Do not pass through or set any environment variables! #
+passenv =
+setenv =
+#########################################################
 deps = -rtest/requirements.txt
 commands = {[testenv:base-command]commands} test/ -m local
 


### PR DESCRIPTION
*Issue #, if available:*

related to: https://github.com/pyca/cryptography/pull/5197

*Description of changes:*

In a recent batch of test refactoring, I inadvertently moved some calls that relied on integ test environment setup (namely: setting certain environment variables) into the test setup that used to be within the test body. This caused these calls to be made during pytest test discovery. This is a problem because we use pytest markers to categorize our tests and test discovery must complete before markers can be applied to filter tests to run.

We have a test (`TOXENV=nocmk`) that should have caught this, but it looks like it was no longer removing the environment variable restrictions. That is fixed now, along with a comment explaining why that is important.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

