### PR TITLE
fix: filtering client suppliers MUST check the client region after creation as well as before

### DIFF
--- a/test/functional/keyrings/aws_kms/test_client_suppliers.py
+++ b/test/functional/keyrings/aws_kms/test_client_suppliers.py
@@ -136,6 +136,30 @@ def test_allow_deny_nested_supplier():
     excinfo.match("Unable to provide client for region 'us-west-2'")
 
 
+def test_deny_region_allowed_region_resolved_by_client_supplier():
+    region = "us-west-2"
+    supplier = DenyRegionsClientSupplier(
+        denied_regions=["us-east-1"], client_supplier=AlwaysOneRegionClientSupplier(region_name=region)
+    )
+
+    # Resolves to a region that is not blocked.
+    test = supplier(None)
+
+    assert test.meta.region_name == region
+
+
+def test_allow_region_allowed_region_resolved_by_client_supplier():
+    region = "us-west-2"
+    supplier = AllowRegionsClientSupplier(
+        allowed_regions=[None, region], client_supplier=AlwaysOneRegionClientSupplier(region_name=region)
+    )
+
+    # Resolves to a region that is allowed
+    test = supplier(None)
+
+    assert test.meta.region_name == region
+
+
 def test_deny_region_block_on_response():
     region = "us-west-2"
     test = DenyRegionsClientSupplier(


### PR DESCRIPTION
*Issue #, if available:*
resolves: #258 

*Description of changes:*

Per #258, this introduces two changes to the filtering client suppliers:
1. They now accept `None` to let users filter out requests when the region is unknown
1. In addition to checking the requested region before calling down to the inner client supplier, they now also check the client returned by the client supplier before returning it. This is to accommodate the scenario where the desired region is unknown and is set in the client by the inner client supplier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

