### PR TITLE
docs: fix typo in example comments

### DIFF
--- a/examples/src/keyring/aws_kms/act_like_aws_kms_master_key_provider.py
+++ b/examples/src/keyring/aws_kms/act_like_aws_kms_master_key_provider.py
@@ -78,7 +78,7 @@ def run(aws_kms_cmk, aws_kms_additional_cmks, source_plaintext):
     # any data keys that were encrypted under an AWS KMS CMK.
     discovery_keyring = AwsKmsKeyring(is_discovery=True)
 
-    # Combine the single-CMK and discovery keyrings
+    # Combine the CMK and discovery keyrings
     # to create a keyring that behaves like an AWS KMS master key provider.
     #
     # The CMK keyring reproduces the encryption behavior


### PR DESCRIPTION
*Description of changes:*

Fixing a typo that I found while reviewing https://github.com/aws/aws-encryption-sdk-java/pull/178

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

