### PR TITLE
chore: clean up and fix test vector handler static analysis checks

### DIFF
--- a/test_vector_handlers/src/awses_test_vectors/__init__.py
+++ b/test_vector_handlers/src/awses_test_vectors/__init__.py
@@ -10,4 +10,5 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Static test vector handling logic for the AWS Encyrption SDK."""
 __version__ = "1.0.0"

--- a/test_vector_handlers/src/awses_test_vectors/commands/__init__.py
+++ b/test_vector_handlers/src/awses_test_vectors/commands/__init__.py
@@ -10,3 +10,4 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""CLI commands."""

--- a/test_vector_handlers/src/awses_test_vectors/commands/full_message_decrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/commands/full_message_decrypt.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""
-AWS Encryption SDK full message decrypt command.
-"""
+"""AWS Encryption SDK full message decrypt command."""
 import argparse
 
 from awses_test_vectors.manifests.full_message.decrypt import MessageDecryptionManifest

--- a/test_vector_handlers/src/awses_test_vectors/commands/full_message_encrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/commands/full_message_encrypt.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""
-AWS Encryption SDK full message encrypt command.
-"""
+"""AWS Encryption SDK full message encrypt command."""
 import argparse
 
 from awses_test_vectors.manifests.full_message.encrypt import MessageEncryptionManifest

--- a/test_vector_handlers/src/awses_test_vectors/internal/__init__.py
+++ b/test_vector_handlers/src/awses_test_vectors/internal/__init__.py
@@ -10,3 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Internal implementation details.
+
+.. warning::
+    No guarantee is provided on the modules and APIs within this
+    namespace staying consistent. Directly reference at your own risk.
+"""

--- a/test_vector_handlers/src/awses_test_vectors/internal/aws_kms.py
+++ b/test_vector_handlers/src/awses_test_vectors/internal/aws_kms.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""
-Helper utilities for interacting with AWS KMS.
-"""
+"""Helper utilities for interacting with AWS KMS."""
 try:
     from aws_encryption_sdk.identifiers import AlgorithmSuite
 except ImportError:

--- a/test_vector_handlers/src/awses_test_vectors/internal/defaults.py
+++ b/test_vector_handlers/src/awses_test_vectors/internal/defaults.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""
-Default values for use in AWS Encryption SDK test vector handlers.
-"""
+"""Default values for use in AWS Encryption SDK test vector handlers."""
 
 ENCODING = "utf-8"

--- a/test_vector_handlers/src/awses_test_vectors/internal/mypy_types.py
+++ b/test_vector_handlers/src/awses_test_vectors/internal/mypy_types.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""
-MyPy types for use in AWS Encryption SDK test vector handlers.
-"""
+"""MyPy types for use in AWS Encryption SDK test vector handlers."""
 # mypy types confuse pylint: disable=invalid-name
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules

--- a/test_vector_handlers/src/awses_test_vectors/internal/util.py
+++ b/test_vector_handlers/src/awses_test_vectors/internal/util.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""
-Utility functions for use in AWS Encryption SDK test vector handlers.
-"""
+"""Utility functions for use in AWS Encryption SDK test vector handlers."""
 import os
 import struct
 from binascii import unhexlify
@@ -100,7 +98,7 @@ def membership_validator(allowed):
     def _validate_membership(instance, attribute, value):
         # type: (object, Attribute, Any) -> None
         # pylint: disable=unused-argument
-        """"""
+        """Perform membership check."""
         if value not in allowed:
             raise ValueError(
                 'Unknown "{name}" value "{actual}" not in {expected}'.format(
@@ -178,9 +176,9 @@ def algorithm_suite_from_string_id(string_id):
     return AlgorithmSuite.get_by_id(numeric_id)
 
 
-# TODO: I want to replace these functions with an extensible "URI Handler" class
-#  that will abstract away any file handling. This will vastly simply extending
-#  these handlers to work with files in some non-local location, such as S3.
+# I want to replace these functions with an extensible "URI Handler" class
+# that will abstract away any file handling. This will vastly simply extending
+# these handlers to work with files in some non-local location, such as S3.
 def file_writer(parent_dir):
     # type: (str) -> Callable[[str, bytes], str]
     """Return a caller that will write the requested named data to a file and return
@@ -214,7 +212,7 @@ def file_writer(parent_dir):
 
 def file_reader(parent_dir):
     # type: (str) -> Callable[[str], bytes]
-    """Returns a callable that accepts a URI identifying a file relative to ``parent_dir``
+    """Return a callable that accepts a URI identifying a file relative to ``parent_dir``
     and returns the binary contents of that file.
 
     :param str parent_dir: Parent directory to use as the relative root for all URIs

--- a/test_vector_handlers/src/awses_test_vectors/manifests/__init__.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/__init__.py
@@ -10,3 +10,4 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Test vector manifest handlers."""

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/__init__.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/__init__.py
@@ -10,3 +10,4 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Full-message test vector manifest handlers."""

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
@@ -51,6 +51,7 @@ SUPPORTED_VERSIONS = (1,)
 
 @attr.s(init=False)
 class MessageDecryptionTestScenario(object):
+    # pylint: disable=too-many-arguments
     """Data class for a single full message decrypt test scenario.
 
     Handles serialization and deserialization to and from manifest specs.
@@ -156,12 +157,12 @@ class MessageDecryptionTestScenario(object):
         """
         plaintext, _header = aws_encryption_sdk.decrypt(source=self.ciphertext, key_provider=self.master_key_provider)
         if plaintext != self.plaintext:
-            # TODO: Actually do something here
-            raise Exception("TODO: ERROR MESSAGE")
+            raise ValueError("Decrypted plaintext does not match expected value.")
 
 
 @attr.s(init=False)
 class MessageDecryptionManifest(object):
+    # pylint: disable=too-many-arguments
     """AWS Encryption SDK Decrypt Message manifest handler.
 
     Described in AWS Crypto Tools Test Vector Framework feature #0003 AWS Encryption SDK Decrypt Message.

--- a/test_vector_handlers/src/awses_test_vectors/manifests/keys.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/keys.py
@@ -108,6 +108,7 @@ class AwsKmsKeySpec(KeySpec):
 
 @attr.s(init=False)
 class ManualKeySpec(KeySpec):
+    # pylint: disable=too-many-arguments
     """Manual key specification.
 
     Allowed values described in AWS Crypto Tools Test Vector Framework feature #0002 Keys Manifest.

--- a/test_vector_handlers/src/pylintrc
+++ b/test_vector_handlers/src/pylintrc
@@ -4,6 +4,7 @@ disable =
     bad-continuation,  # we let black handle this
     ungrouped-imports,  # we let isort handle this
     useless-object-inheritance,  # we need to support Python 2, so no, not useless
+    duplicate-code,  # the manifest handlers have a lot of similar code
 
 [FORMAT]
 max-line-length = 120

--- a/test_vector_handlers/test/pylintrc
+++ b/test_vector_handlers/test/pylintrc
@@ -1,0 +1,16 @@
+[MESSAGES CONTROL]
+# Disabling messages that we either don't care about for tests or are necessary to break for tests.
+disable =
+    invalid-name,  # we prefer long, descriptive, names for tests
+    missing-docstring,  # we don't write docstrings for tests
+    bad-continuation,  # we let black handle this
+    ungrouped-imports,  # we let isort handle this
+    useless-object-inheritance,  # we need to support Python 2, so no, not useless
+    duplicate-code,  # unit tests for similar things tend to be similar
+    redefined-outer-name,  # raised when using decorators
+
+[FORMAT]
+max-line-length = 120
+
+[REPORTS]
+msg-template = {path}:{line}: [{msg_id}({symbol}), {obj}] {msg}

--- a/test_vector_handlers/tox.ini
+++ b/test_vector_handlers/tox.ini
@@ -145,8 +145,6 @@ deps = {[testenv:pylint]deps}
 commands =
     pylint \
         --rcfile=test/pylintrc \
-        test/unit/ \
-        test/functional/ \
         test/integration/ \
         {posargs}
 


### PR DESCRIPTION
*Description of changes:*

This cleans up some outstanding issues with the test vector handler static analysis checks that have been sitting around since they were written. I originally had these checks disabled in Travis with a plan to come back and fix and enable them later, but later never came. When I moved those checks over to GitHub Actions I decided to enable them as a reminder to actually fix them. This change addresses the issue and will let us lock down our remaining CI checks as required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

