### PR TITLE
hanging object references in helper functions avoided

### DIFF
--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -15,6 +15,7 @@ from aws_encryption_sdk.streaming_client import (  # noqa
     StreamEncryptor,
 )
 from aws_encryption_sdk.structures import CryptoResult
+import copy
 
 __all__ = ("encrypt", "decrypt", "stream")
 
@@ -84,7 +85,10 @@ def encrypt(**kwargs):
     with StreamEncryptor(**kwargs) as encryptor:
         ciphertext = encryptor.read()
 
-    return CryptoResult(result=ciphertext, header=encryptor.header, keyring_trace=encryptor.keyring_trace)
+    header_copy = copy.deepcopy(encryptor.header)
+    keyring_trace_copy = copy.deepcopy(encryptor.keyring_trace)
+
+    return CryptoResult(result=ciphertext, header=header_copy, keyring_trace=keyring_trace_copy)
 
 
 def decrypt(**kwargs):
@@ -143,7 +147,10 @@ def decrypt(**kwargs):
     with StreamDecryptor(**kwargs) as decryptor:
         plaintext = decryptor.read()
 
-    return CryptoResult(result=plaintext, header=decryptor.header, keyring_trace=decryptor.keyring_trace)
+    header_copy = copy.deepcopy(decryptor.header)
+    keyring_trace_copy = copy.deepcopy(decryptor.keyring_trace)
+
+    return CryptoResult(result=plaintext, header=header_copy, keyring_trace=keyring_trace_copy)
 
 
 def stream(**kwargs):

--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """High level AWS Encryption SDK client functions."""
+import copy
+
 # Below are imported for ease of use by implementors
 from aws_encryption_sdk.caches.local import LocalCryptoMaterialsCache  # noqa
 from aws_encryption_sdk.caches.null import NullCryptoMaterialsCache  # noqa
@@ -15,7 +17,6 @@ from aws_encryption_sdk.streaming_client import (  # noqa
     StreamEncryptor,
 )
 from aws_encryption_sdk.structures import CryptoResult
-import copy
 
 __all__ = ("encrypt", "decrypt", "stream")
 

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -53,13 +53,15 @@ class TestAwsEncryptionSdk(object):
         test_ciphertext, test_header = aws_encryption_sdk.encrypt(a=sentinel.a, b=sentinel.b, c=sentinel.b)
         self.mock_stream_encryptor.called_once_with(a=sentinel.a, b=sentinel.b, c=sentinel.b)
         assert test_ciphertext is _CIPHERTEXT
-        assert test_header is _HEADER
+        assert test_header == _HEADER
+        assert test_header is not _HEADER
 
     def test_decrypt(self):
         test_plaintext, test_header = aws_encryption_sdk.decrypt(a=sentinel.a, b=sentinel.b, c=sentinel.b)
         self.mock_stream_encryptor.called_once_with(a=sentinel.a, b=sentinel.b, c=sentinel.b)
         assert test_plaintext is _PLAINTEXT
-        assert test_header is _HEADER
+        assert test_header == _HEADER
+        assert test_header is not _HEADER
 
     def test_stream_encryptor_e(self):
         test = aws_encryption_sdk.stream(mode="e", a=sentinel.a, b=sentinel.b, c=sentinel.b)


### PR DESCRIPTION
resolves: #44 

*Description of changes:*
- Avoided hanging object references in helper functions -
   * Created a deep copy of header and keyring trace objects from the managed stream before passing them to `CryptoResult` in the `encrypt`[1] and `decrypt`[2] functions.
    * Modified the test for checking equality of header but not identity

 [1] https://github.com/aws/aws-encryption-sdk-python/blob/82e21567a7111aea99a364e19842c3fa87a081bb/src/aws_encryption_sdk/__init__.py#L84-L87
[2] https://github.com/aws/aws-encryption-sdk-python/blob/82e21567a7111aea99a364e19842c3fa87a081bb/src/aws_encryption_sdk/__init__.py#L143-L146

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.