### PR TITLE
chore: update pylint settings to match changes in 2.5.0

### DIFF
--- a/src/aws_encryption_sdk/internal/validators.py
+++ b/src/aws_encryption_sdk/internal/validators.py
@@ -11,6 +11,9 @@ except ImportError:  # pragma: no cover
     pass
 
 
+# The unused-argument check is disabled because
+# this function MUST match the function signature
+# for attrs validators.
 def value_is_not_a_string(instance, attribute, value):  # pylint: disable=unused-argument
     # type: (Any, attr.Attribute, Any) -> None
     """Technically a string is an iterable containing strings.

--- a/src/aws_encryption_sdk/internal/validators.py
+++ b/src/aws_encryption_sdk/internal/validators.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cover
     pass
 
 
-def value_is_not_a_string(instance, attribute, value):
+def value_is_not_a_string(instance, attribute, value):  # pylint: disable=unused-argument
     # type: (Any, attr.Attribute, Any) -> None
     """Technically a string is an iterable containing strings.
 

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
@@ -157,7 +157,7 @@ class MessageDecryptionTestScenario(object):
         """
         plaintext, _header = aws_encryption_sdk.decrypt(source=self.ciphertext, key_provider=self.master_key_provider)
         if plaintext != self.plaintext:
-            raise ValueError("Decrypted plaintext does not match expected value.")
+            raise ValueError("Decrypted plaintext does not match expected value for scenario '{}'".format(name))
 
 
 @attr.s(init=False)


### PR DESCRIPTION
*Description of changes:*

`pylint` 2.5.0 landed yesterday and it looks like its unused argument rules changed slightly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

