### PR TITLE
docs: add links to custom AWS KMS client configuration examples in examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,10 @@ We start with AWS KMS examples, then show how to use other wrapping keys.
         * [with keyrings](./src/keyring/aws_kms/discovery_decrypt_with_preferred_regions.py)
     * How to reproduce the behavior of an AWS KMS master key provider
         * [with keyrings](./src/keyring/aws_kms/act_like_aws_kms_master_key_provider.py)
+    * How to provide a custom AWS KMS client configuration
+        * [with keyrings](./src/keyring/aws_kms/custom_kms_client_config.py)
+    * How to provide a custom AWS KMS client supplier
+        * [with keyrings](./src/keyring/aws_kms/custom_client_supplier.py)
 * Using raw wrapping keys
     * How to use a raw AES wrapping key
         * [with keyrings](./src/keyring/raw_aes/raw_aes.py)

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,9 +46,9 @@ We start with AWS KMS examples, then show how to use other wrapping keys.
         * [with keyrings](./src/keyring/aws_kms/discovery_decrypt_with_preferred_regions.py)
     * How to reproduce the behavior of an AWS KMS master key provider
         * [with keyrings](./src/keyring/aws_kms/act_like_aws_kms_master_key_provider.py)
-    * How to provide a custom AWS KMS client configuration
+    * How to use AWS KMS clients with custom configuration
         * [with keyrings](./src/keyring/aws_kms/custom_kms_client_config.py)
-    * How to provide a custom AWS KMS client supplier
+    * How to use different AWS KMS client for different regions
         * [with keyrings](./src/keyring/aws_kms/custom_client_supplier.py)
 * Using raw wrapping keys
     * How to use a raw AES wrapping key


### PR DESCRIPTION
*Description of changes:*

In going through to enumerate the examples for https://github.com/awslabs/aws-encryption-sdk-specification/issues/103, I realized that the client supplier examples were not linked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

