### PR TITLE
fix(raw-keyrings): Raise when passed a key_namespace of "aws-kms"

### DIFF
--- a/src/aws_encryption_sdk/keyrings/aws_kms/__init__.py
+++ b/src/aws_encryption_sdk/keyrings/aws_kms/__init__.py
@@ -25,6 +25,7 @@ from .client_suppliers import ClientSupplier  # noqa - only used in docstring pa
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Dict, Iterable, Union  # noqa pylint: disable=unused-import
+
     from .client_suppliers import ClientSupplierType  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -74,6 +74,10 @@ class RawAESKeyring(Keyring):
     .. versionadded:: 1.5.0
 
     :param str key_namespace: String defining the keyring.
+
+    .. note::
+        key_namespace MUST NOT equal "aws-kms".
+
     :param bytes key_name: Key ID
     :param bytes wrapping_key: Encryption key with which to wrap plaintext data key.
 
@@ -97,6 +101,9 @@ class RawAESKeyring(Keyring):
                 WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
             )
         }
+
+        if self.key_namespace == "aws-kms":
+            raise ValueError("Key namespace MUST NOT be \"aws-kms\"")
 
         try:
             self._wrapping_algorithm = key_size_to_wrapping_algorithm[len(self._wrapping_key)]
@@ -245,6 +252,10 @@ class RawRSAKeyring(Keyring):
     .. versionadded:: 1.5.0
 
     :param str key_namespace: String defining the keyring ID
+
+    .. note::
+        key_namespace MUST NOT equal "aws-kms".
+
     :param bytes key_name: Key ID
     :param cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey private_wrapping_key:
         Private encryption key with which to wrap plaintext data key (optional)
@@ -279,6 +290,9 @@ class RawRSAKeyring(Keyring):
         # type: () -> None
         """Prepares initial values not handled by attrs."""
         self._key_provider = MasterKeyInfo(provider_id=self.key_namespace, key_info=self.key_name)
+
+        if self.key_namespace == "aws-kms":
+            raise ValueError("Key namespace MUST NOT be \"aws-kms\"")
 
         if self._public_wrapping_key is None and self._private_wrapping_key is None:
             raise TypeError("At least one of public key or private key must be provided.")

--- a/src/aws_encryption_sdk/keyrings/raw.py
+++ b/src/aws_encryption_sdk/keyrings/raw.py
@@ -103,7 +103,7 @@ class RawAESKeyring(Keyring):
         }
 
         if self.key_namespace == "aws-kms":
-            raise ValueError("Key namespace MUST NOT be \"aws-kms\"")
+            raise ValueError('Key namespace MUST NOT be "aws-kms"')
 
         try:
             self._wrapping_algorithm = key_size_to_wrapping_algorithm[len(self._wrapping_key)]
@@ -292,7 +292,7 @@ class RawRSAKeyring(Keyring):
         self._key_provider = MasterKeyInfo(provider_id=self.key_namespace, key_info=self.key_name)
 
         if self.key_namespace == "aws-kms":
-            raise ValueError("Key namespace MUST NOT be \"aws-kms\"")
+            raise ValueError('Key namespace MUST NOT be "aws-kms"')
 
         if self._public_wrapping_key is None and self._private_wrapping_key is None:
             raise TypeError("At least one of public key or private key must be provided.")

--- a/test/functional/keyrings/raw/test_raw_aes.py
+++ b/test/functional/keyrings/raw/test_raw_aes.py
@@ -190,10 +190,8 @@ def test_must_not_accept_aws_kms():
     # Attempt to instantiate a raw AES keyring
     with pytest.raises(ValueError) as excinfo:
         RawAESKeyring(
-            key_namespace=key_namespace,
-            key_name=key_name,
-            wrapping_key=_WRAPPING_KEY,
+            key_namespace=key_namespace, key_name=key_name, wrapping_key=_WRAPPING_KEY,
         )
 
     # Check the error message
-    excinfo.match("Key namespace MUST NOT be \"aws-kms\"")
+    excinfo.match('Key namespace MUST NOT be "aws-kms"')

--- a/test/functional/keyrings/raw/test_raw_aes.py
+++ b/test/functional/keyrings/raw/test_raw_aes.py
@@ -179,3 +179,21 @@ def test_key_info_prefix_vectors(wrapping_algorithm):
         )
         == _KEY_ID + b"\x00\x00\x00\x80\x00\x00\x00\x0c"
     )
+
+
+def test_must_not_accept_aws_kms():
+
+    # Initializing attributes
+    key_namespace = "aws-kms"
+    key_name = _KEY_ID
+
+    # Attempt to instantiate a raw AES keyring
+    with pytest.raises(ValueError) as excinfo:
+        RawAESKeyring(
+            key_namespace=key_namespace,
+            key_name=key_name,
+            wrapping_key=_WRAPPING_KEY,
+        )
+
+    # Check the error message
+    excinfo.match("Key namespace MUST NOT be \"aws-kms\"")

--- a/test/functional/keyrings/raw/test_raw_rsa.py
+++ b/test/functional/keyrings/raw/test_raw_rsa.py
@@ -385,4 +385,4 @@ def test_must_not_accept_aws_kms():
             public_wrapping_key=_PUBLIC_WRAPPING_KEY,
         )
 
-    excinfo.match("Key namespace MUST NOT be \"aws-kms\"")
+    excinfo.match('Key namespace MUST NOT be "aws-kms"')

--- a/test/functional/keyrings/raw/test_raw_rsa.py
+++ b/test/functional/keyrings/raw/test_raw_rsa.py
@@ -371,3 +371,18 @@ def test_keypair_must_match():
         )
 
     excinfo.match("Private and public wrapping keys MUST be from the same keypair.")
+
+
+def test_must_not_accept_aws_kms():
+    bad_key_namespace = "aws-kms"
+
+    with pytest.raises(ValueError) as excinfo:
+        RawRSAKeyring(
+            key_namespace=bad_key_namespace,
+            key_name=_KEY_ID,
+            wrapping_algorithm=_WRAPPING_ALGORITHM,
+            private_wrapping_key=_PRIVATE_WRAPPING_KEY,
+            public_wrapping_key=_PUBLIC_WRAPPING_KEY,
+        )
+
+    excinfo.match("Key namespace MUST NOT be \"aws-kms\"")


### PR DESCRIPTION
*Issue #, if available:* #279 

*Description of changes:* 
Implement spec changed introduced in https://github.com/awslabs/aws-encryption-sdk-specification/pull/140. Initialization now throws in both raw keyrings is `key_namespace` equals `"aws-kms"`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

