### PR TITLE
chore: apply changes to accomodate updated Pylint checks

### DIFF
--- a/decrypt_oracle/.chalice/pipeline.py
+++ b/decrypt_oracle/.chalice/pipeline.py
@@ -37,7 +37,7 @@ class AllowEverywhere(AWS.Statement):
         """Set up override values."""
         my_kwargs = dict(Effect=AWS.Allow, Resource=["*"])
         my_kwargs.update(kwargs)
-        super(AllowEverywhere, self).__init__(*args, **my_kwargs)
+        super().__init__(*args, **my_kwargs)
 
 
 def _service_assume_role(service: str) -> AWS.Policy:

--- a/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/key_providers/counting.py
+++ b/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/key_providers/counting.py
@@ -30,7 +30,7 @@ class CountingMasterKeyConfig(MasterKeyConfig):
 
     def __init__(self) -> None:
         """Set the key id to "test_counting_prov_info"."""
-        super(CountingMasterKeyConfig, self).__init__(key_id=b"test_counting_prov_info")
+        super().__init__(key_id=b"test_counting_prov_info")
 
 
 class CountingMasterKey(MasterKey):

--- a/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/key_providers/null.py
+++ b/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/key_providers/null.py
@@ -26,7 +26,7 @@ class NullMasterKeyConfig(MasterKeyConfig):
 
     def __init__(self) -> None:
         """Set the key id to "null"."""
-        super(NullMasterKeyConfig, self).__init__(key_id=b"null")
+        super().__init__(key_id=b"null")
 
 
 class NullMasterKey(MasterKey):

--- a/decrypt_oracle/src/pylintrc
+++ b/decrypt_oracle/src/pylintrc
@@ -3,7 +3,6 @@
 disable =
     bad-continuation,  # we let black handle this
     ungrouped-imports,  # we let isort handle this
-    useless-object-inheritance,  # we need to support Python 2, so no, not useless
 
 [FORMAT]
 max-line-length = 120

--- a/decrypt_oracle/test/integration/integration_test_utils.py
+++ b/decrypt_oracle/test/integration/integration_test_utils.py
@@ -38,13 +38,13 @@ def decrypt_endpoint() -> Text:
     try:
         deployment_id = os.environ[DEPLOYMENT_ID]
         region = os.environ[DEPLOYMENT_REGION]
-    except KeyError:
+    except KeyError as error:
         raise ValueError(
             (
                 'Environment variables "{region}" and "{deployment}" '
                 "must be set to the correct values for the deployed decrypt oracle."
             ).format(region=DEPLOYMENT_REGION, deployment=DEPLOYMENT_ID)
-        )
+        ) from error
 
     _ENDPOINT = "https://{deployment_id}.execute-api.{region}.amazonaws.com/api/v0/decrypt".format(
         deployment_id=deployment_id, region=region
@@ -56,12 +56,12 @@ def get_cmk_arn() -> Text:
     """Retrieve the target CMK ARN from environment variable."""
     try:
         arn = os.environ[AWS_KMS_KEY_ID]
-    except KeyError:
+    except KeyError as error:
         raise ValueError(
             'Environment variable "{}" must be set to a valid KMS CMK ARN for integration tests to run'.format(
                 AWS_KMS_KEY_ID
             )
-        )
+        ) from error
 
     if arn.startswith("arn:") and ":alias/" not in arn:
         return arn

--- a/src/pylintrc
+++ b/src/pylintrc
@@ -5,12 +5,15 @@ disable =
     ungrouped-imports,  # we let isort handle this
     no-member,  # breaks with attrs
     no-self-use,  # interesting to keep in mind for later refactoring, but not blocking
-    useless-object-inheritance,  # we need to support Python 2, so no, not useless
     too-few-public-methods,  # does not allow value stores
     no-else-return,  # we omit this on purpose for brevity where it would add no value
     attribute-defined-outside-init,  # breaks with attrs_post_init
     abstract-method,  # throws false positives on io.BaseIO grandchildren
     redefined-outer-name,  # we do this on purpose in multiple places
+    # All below are disabled because we need to support Python 2
+    useless-object-inheritance,
+    raise-missing-from,
+    super-with-arguments,
 
 [BASIC]
 # Allow function names up to 50 characters

--- a/test/pylintrc
+++ b/test/pylintrc
@@ -8,7 +8,6 @@ disable =
     abstract-class-instantiated,  # we do this on purpose to test that they are enforced
     no-member,  # raised on patched objects with mock checks
     no-self-use,  # common pattern when using pytest classes: can be enabled once all tests are refactored to pytest functions
-    useless-object-inheritance,  # we need to support Python 2, so no, not useless
     duplicate-code,  # unit tests for similar things tend to be similar
     too-many-instance-attributes,  # common pattern when using pytest classes: can be enabled once all tests are refactored to pytest functions
     too-few-public-methods,  # common when setting up mock classes
@@ -19,6 +18,10 @@ disable =
     abstract-method,  # we do this on purpose to test that they are enforced
     redefined-outer-name,  # raised when using decorators
     unused-argument,  # raised when patches are needed but not called
+    # All below are disabled because we need to support Python 2
+    useless-object-inheritance,
+    raise-missing-from,
+    super-with-arguments,
 
 [VARIABLES]
 additional-builtins = raw_input

--- a/test_vector_handlers/src/pylintrc
+++ b/test_vector_handlers/src/pylintrc
@@ -3,8 +3,11 @@
 disable =
     bad-continuation,  # we let black handle this
     ungrouped-imports,  # we let isort handle this
-    useless-object-inheritance,  # we need to support Python 2, so no, not useless
     duplicate-code,  # the manifest handlers have a lot of similar code
+    # All below are disabled because we need to support Python 2
+    useless-object-inheritance,
+    raise-missing-from,
+    super-with-arguments,
 
 [FORMAT]
 max-line-length = 120

--- a/test_vector_handlers/test/pylintrc
+++ b/test_vector_handlers/test/pylintrc
@@ -5,9 +5,12 @@ disable =
     missing-docstring,  # we don't write docstrings for tests
     bad-continuation,  # we let black handle this
     ungrouped-imports,  # we let isort handle this
-    useless-object-inheritance,  # we need to support Python 2, so no, not useless
     duplicate-code,  # unit tests for similar things tend to be similar
     redefined-outer-name,  # raised when using decorators
+    # All below are disabled because we need to support Python 2
+    useless-object-inheritance,
+    raise-missing-from,
+    super-with-arguments,
 
 [FORMAT]
 max-line-length = 120


### PR DESCRIPTION
*Description of changes:*

Recent versions of Pylint added some new checks that recommend using syntax that was introduced in Python 3. This required two changes on our part:

1. The decrypt oracle is Python 3 only. There, I actually made the recommended changes (and re-enabled a similar check that was incorrectly disabled.)
1. Everywhere else, disable the new checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

