### PR TITLE
chore: centralize twine configuration logic and remove dependency on pypirc

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,9 @@ passenv =
     # Pass through AWS credentials
     AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
     # Pass through AWS profile name (useful for local testing)
-    AWS_PROFILE
+    AWS_PROFILE \
+    # Pass through custom pip config file settings
+    PIP_CONFIG_FILE
 sitepackages = False
 deps = -rtest/requirements.txt
 commands =
@@ -332,22 +334,39 @@ deps =
 commands =
     python setup.py sdist bdist_wheel
 
-[testenv:test-release]
+[testenv:release-base]
 basepython = python3
 skip_install = true
 deps =
     {[testenv:build]deps}
     twine
+passenv =
+    {[testenv]passenv} \
+    TWINE_USERNAME \
+    TWINE_PASSWORD \
+    TWINE_REPOSITORY_URL
 commands =
     {[testenv:build]commands}
-    twine upload --skip-existing --repository testpypi dist/*
+    twine upload --skip-existing {toxinidir}/dist/*
+
+[testenv:test-release]
+basepython = python3
+skip_install = true
+deps = {[testenv:release-base]deps}
+passenv =
+    {[testenv:release-base]passenv}
+setenv =
+    TWINE_REPOSITORY_URL = https://test.pypi.org/legacy/
+commands = {[testenv:release-base]commands}
 
 [testenv:release]
 basepython = python3
 skip_install = true
-deps =
-    {[testenv:build]deps}
-    twine
+deps = {[testenv:release-base]deps}
+passenv =
+    {[testenv:release-base]passenv}
+whitelist_externals = unset
 commands =
-    {[testenv:build]commands}
-    twine upload --skip-existing --repository pypi dist/*
+    # Unsetting the TWINE_REPOSITORY_URL defaults twine to using production PyPI
+    unset TWINE_REPOSITORY_URL
+    {[testenv:release-base]commands}


### PR DESCRIPTION
*Description of changes:*

This change shifts the twine configuration from depending entirely on `.pypirc` to be configured as expected to instead rely on `twine` and `pip` environment variable configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

