### PR TITLE
Post 2.0.0 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,12 +56,12 @@ matrix:
     - python: 2.7
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py27-awses_1.3.3
+        TOXENV=py27-awses_1.7.1
       stage: Test Vector Handler Tests
     - python: 2.7
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py27-awses_1.3.max
+        TOXENV=py27-awses_2.0.0
       stage: Test Vector Handler Tests
     - python: 2.7
       env:
@@ -72,12 +72,12 @@ matrix:
     - python: 3.5
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py35-awses_1.3.3
+        TOXENV=py35-awses_1.7.1
       stage: Test Vector Handler Tests
     - python: 3.5
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py35-awses_1.3.max
+        TOXENV=py35-awses_2.0.0
       stage: Test Vector Handler Tests
     - python: 3.5
       env:
@@ -88,12 +88,12 @@ matrix:
     - python: 3.6
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py36-awses_1.3.3
+        TOXENV=py36-awses_1.7.1
       stage: Test Vector Handler Tests
     - python: 3.6
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py36-awses_1.3.max
+        TOXENV=py36-awses_2.0.0
       stage: Test Vector Handler Tests
     - python: 3.6
       env:
@@ -104,14 +104,14 @@ matrix:
     - python: 3.7
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py37-awses_1.3.3
+        TOXENV=py37-awses_1.7.1
       dist: xenial
       sudo: true
       stage: Test Vector Handler Tests
     - python: 3.7
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py37-awses_1.3.max
+        TOXENV=py37-awses_2.0.0
       dist: xenial
       sudo: true
       stage: Test Vector Handler Tests
@@ -126,14 +126,14 @@ matrix:
     - python: 3.8
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py38-awses_1.3.3
+        TOXENV=py38-awses_1.7.1
       dist: xenial
       sudo: true
       stage: Test Vector Handler Tests
     - python: 3.8
       env:
         TEST_VECTOR_HANDLERS=1
-        TOXENV=py38-awses_1.3.max
+        TOXENV=py38-awses_2.0.0
       dist: xenial
       sudo: true
       stage: Test Vector Handler Tests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 
 Features
 --------
-* Updates to the AWS Encryption SDK. 1cceceb
+* Updates to the AWS Encryption SDK. 73cce71
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ for more details.
 
 Features
 --------
-* Updates to the AWS Encryption SDK. bdbf00c
+* Updates to the AWS Encryption SDK. ef90351
 
 Deprecations
 ^^^^^^^^^^^^

--- a/decrypt_oracle/test/integration/integration_test_utils.py
+++ b/decrypt_oracle/test/integration/integration_test_utils.py
@@ -17,7 +17,9 @@ import os
 from collections import namedtuple
 from typing import Any, Callable, Iterable, Optional, Text
 
+import aws_encryption_sdk
 import pytest
+from aws_encryption_sdk.identifiers import CommitmentPolicy
 from aws_encryption_sdk.key_providers.kms import StrictAwsKmsMasterKeyProvider
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -26,6 +28,8 @@ DEPLOYMENT_ID = "AWS_ENCRYPTION_SDK_PYTHON_DECRYPT_ORACLE_API_DEPLOYMENT_ID"
 AWS_KMS_KEY_ID = "AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID"
 _KMS_MKP = None
 _ENDPOINT = None
+
+CLIENT = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
 
 
 def decrypt_endpoint() -> Text:

--- a/decrypt_oracle/test/integration/integration_test_utils.py
+++ b/decrypt_oracle/test/integration/integration_test_utils.py
@@ -18,7 +18,7 @@ from collections import namedtuple
 from typing import Any, Callable, Iterable, Optional, Text
 
 import pytest
-from aws_encryption_sdk.key_providers.kms import KMSMasterKeyProvider
+from aws_encryption_sdk.key_providers.kms import StrictAwsKmsMasterKeyProvider
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 DEPLOYMENT_REGION = "AWS_ENCRYPTION_SDK_PYTHON_DECRYPT_ORACLE_REGION"
@@ -77,7 +77,7 @@ def kms_master_key_provider(cache: Optional[bool] = True):
         return _KMS_MKP
 
     cmk_arn = get_cmk_arn()
-    _kms_master_key_provider = KMSMasterKeyProvider(key_ids=[cmk_arn])
+    _kms_master_key_provider = StrictAwsKmsMasterKeyProvider(key_ids=[cmk_arn])
 
     if cache:
         _KMS_MKP = _kms_master_key_provider

--- a/decrypt_oracle/test/unit/key_providers/test_u_counting.py
+++ b/decrypt_oracle/test/unit/key_providers/test_u_counting.py
@@ -11,12 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Unit test for ``aws_encryption_sdk_decrypt_oracle.key_providers.counting``."""
-import aws_encryption_sdk
 import pytest
 from aws_encryption_sdk_decrypt_oracle.key_providers.counting import CountingMasterKey
 
-from aws_encryption_sdk.identifiers import CommitmentPolicy
-from ...integration.integration_test_utils import filtered_test_vectors
+from ...integration.integration_test_utils import CLIENT, filtered_test_vectors
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
@@ -24,8 +22,8 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 @pytest.mark.parametrize("vector", filtered_test_vectors(lambda x: x.key_type == "test_counting"))
 def test_counting_master_key_decrypt_vectors(vector):
     master_key = CountingMasterKey()
-    client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
-    plaintext, _header = client.decrypt(source=vector.ciphertext, key_provider=master_key)
+
+    plaintext, _header = CLIENT.decrypt(source=vector.ciphertext, key_provider=master_key)
 
     assert plaintext == vector.plaintext
 
@@ -34,10 +32,8 @@ def test_counting_master_key_cycle():
     plaintext = b"some super secret plaintext"
     master_key = CountingMasterKey()
 
-    client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
-
-    ciphertext, _header = client.encrypt(source=plaintext, key_provider=master_key)
-    decrypted, _header = client.decrypt(source=ciphertext, key_provider=master_key)
+    ciphertext, _header = CLIENT.encrypt(source=plaintext, key_provider=master_key)
+    decrypted, _header = CLIENT.decrypt(source=ciphertext, key_provider=master_key)
 
     assert plaintext != ciphertext
     assert plaintext == decrypted

--- a/decrypt_oracle/test/unit/key_providers/test_u_null.py
+++ b/decrypt_oracle/test/unit/key_providers/test_u_null.py
@@ -15,6 +15,7 @@ import aws_encryption_sdk
 import pytest
 from aws_encryption_sdk_decrypt_oracle.key_providers.null import NullMasterKey
 
+from aws_encryption_sdk.identifiers import CommitmentPolicy
 from ...integration.integration_test_utils import filtered_test_vectors
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
@@ -23,8 +24,8 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 @pytest.mark.parametrize("vector", filtered_test_vectors(lambda x: x.key_type == "null"))
 def test_null_master_key_decrypt_vectors(vector):
     master_key = NullMasterKey()
-
-    plaintext, _header = aws_encryption_sdk.decrypt(source=vector.ciphertext, key_provider=master_key)
+    client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
+    plaintext, _header = client.decrypt(source=vector.ciphertext, key_provider=master_key)
 
     assert plaintext == vector.plaintext
 
@@ -32,9 +33,10 @@ def test_null_master_key_decrypt_vectors(vector):
 def test_null_master_key_cycle():
     plaintext = b"some super secret plaintext"
     master_key = NullMasterKey()
+    client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
 
-    ciphertext, _header = aws_encryption_sdk.encrypt(source=plaintext, key_provider=master_key)
-    decrypted, _header = aws_encryption_sdk.decrypt(source=ciphertext, key_provider=master_key)
+    ciphertext, _header = client.encrypt(source=plaintext, key_provider=master_key)
+    decrypted, _header = client.decrypt(source=ciphertext, key_provider=master_key)
 
     assert plaintext != ciphertext
     assert plaintext == decrypted

--- a/decrypt_oracle/test/unit/key_providers/test_u_null.py
+++ b/decrypt_oracle/test/unit/key_providers/test_u_null.py
@@ -11,12 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Unit test for ``aws_encryption_sdk_decrypt_oracle.key_providers.null``."""
-import aws_encryption_sdk
 import pytest
 from aws_encryption_sdk_decrypt_oracle.key_providers.null import NullMasterKey
 
-from aws_encryption_sdk.identifiers import CommitmentPolicy
-from ...integration.integration_test_utils import filtered_test_vectors
+from ...integration.integration_test_utils import CLIENT, filtered_test_vectors
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
@@ -24,8 +22,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 @pytest.mark.parametrize("vector", filtered_test_vectors(lambda x: x.key_type == "null"))
 def test_null_master_key_decrypt_vectors(vector):
     master_key = NullMasterKey()
-    client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
-    plaintext, _header = client.decrypt(source=vector.ciphertext, key_provider=master_key)
+    plaintext, _header = CLIENT.decrypt(source=vector.ciphertext, key_provider=master_key)
 
     assert plaintext == vector.plaintext
 
@@ -33,10 +30,9 @@ def test_null_master_key_decrypt_vectors(vector):
 def test_null_master_key_cycle():
     plaintext = b"some super secret plaintext"
     master_key = NullMasterKey()
-    client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
 
-    ciphertext, _header = client.encrypt(source=plaintext, key_provider=master_key)
-    decrypted, _header = client.decrypt(source=ciphertext, key_provider=master_key)
+    ciphertext, _header = CLIENT.encrypt(source=plaintext, key_provider=master_key)
+    decrypted, _header = CLIENT.decrypt(source=ciphertext, key_provider=master_key)
 
     assert plaintext != ciphertext
     assert plaintext == decrypted

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -75,6 +75,8 @@ class _ClientConfig(object):
 
     :param source: Source data to encrypt or decrypt
     :type source: str, bytes, io.IOBase, or file
+    :param commitment_policy: The commitment policy to use during encryption and decryption
+    :type commitment_policy: aws_encryption_sdk.identifiers.CommitmentPolicy
     :param materials_manager: `CryptoMaterialsManager` from which to obtain cryptographic materials
         (either `materials_manager` or `key_provider` required)
     :type materials_manager: aws_encryption_sdk.materials_manager.base.CryptoMaterialsManager

--- a/test_vector_handlers/compatibility-requirements/1.7.1
+++ b/test_vector_handlers/compatibility-requirements/1.7.1
@@ -1,0 +1,2 @@
+aws-encryption-sdk==1.7.1
+attrs<19.2.0

--- a/test_vector_handlers/compatibility-requirements/2.0.0
+++ b/test_vector_handlers/compatibility-requirements/2.0.0
@@ -1,0 +1,2 @@
+aws-encryption-sdk==2.0.0
+attrs<19.2.0

--- a/test_vector_handlers/src/awses_test_vectors/internal/aws_kms.py
+++ b/test_vector_handlers/src/awses_test_vectors/internal/aws_kms.py
@@ -15,12 +15,12 @@ try:
     from aws_encryption_sdk.identifiers import AlgorithmSuite
 except ImportError:
     from aws_encryption_sdk.identifiers import Algorithm as AlgorithmSuite
-from aws_encryption_sdk.key_providers.kms import KMSMasterKeyProvider
+from aws_encryption_sdk.key_providers.kms import DiscoveryAwsKmsMasterKeyProvider, StrictAwsKmsMasterKeyProvider
 
 from awses_test_vectors.internal.defaults import ENCODING
 
 # This lets us easily use a single boto3 client per region for all KMS master keys.
-KMS_MASTER_KEY_PROVIDER = KMSMasterKeyProvider()
+KMS_MASTER_KEY_PROVIDER = DiscoveryAwsKmsMasterKeyProvider()
 
 
 def arn_from_key_id(key_id):
@@ -34,7 +34,8 @@ def arn_from_key_id(key_id):
     :returns: Full Arn for KMS CMK that key ID identifies
     :rtype: str
     """
-    encrypted_data_key = KMS_MASTER_KEY_PROVIDER.master_key(key_id.encode(ENCODING)).generate_data_key(
+    provider = StrictAwsKmsMasterKeyProvider(key_ids=[key_id])
+    encrypted_data_key = provider.master_key(key_id.encode(ENCODING)).generate_data_key(
         algorithm=AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryption_context={}
     )
     return encrypted_data_key.key_provider.key_info.decode(ENCODING)

--- a/test_vector_handlers/src/awses_test_vectors/internal/mypy_types.py
+++ b/test_vector_handlers/src/awses_test_vectors/internal/mypy_types.py
@@ -15,10 +15,10 @@
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import (  # noqa pylint: disable=unused-import
+        IO,
         Any,
         Callable,
         Dict,
-        IO,
         Iterable,
         Optional,
         Tuple,

--- a/test_vector_handlers/src/awses_test_vectors/internal/util.py
+++ b/test_vector_handlers/src/awses_test_vectors/internal/util.py
@@ -25,6 +25,7 @@ except ImportError:
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Any, Callable, Dict, Iterable, Type  # noqa pylint: disable=unused-import
+
     from awses_test_vectors.internal.mypy_types import (  # noqa pylint: disable=unused-import
         ISINSTANCE,
         MANIFEST_VERSION,

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
@@ -21,6 +21,7 @@ import os
 import attr
 import aws_encryption_sdk
 import six
+from aws_encryption_sdk.identifiers import CommitmentPolicy
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider
 
 from awses_test_vectors.internal.defaults import ENCODING
@@ -34,7 +35,8 @@ from awses_test_vectors.manifests.keys import KeysManifest
 from awses_test_vectors.manifests.master_key import MasterKeySpec, master_key_provider_from_master_key_specs
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from typing import Callable, Dict, IO, Iterable, Optional  # noqa pylint: disable=unused-import
+    from typing import IO, Callable, Dict, Iterable, Optional  # noqa pylint: disable=unused-import
+
     from awses_test_vectors.internal.mypy_types import (  # noqa pylint: disable=unused-import
         DECRYPT_SCENARIO_SPEC,
         FULL_MESSAGE_DECRYPT_MANIFEST,
@@ -155,7 +157,8 @@ class MessageDecryptionTestScenario(object):
 
         :param str name: Descriptive name for this scenario to use in any logging or errors
         """
-        plaintext, _header = aws_encryption_sdk.decrypt(source=self.ciphertext, key_provider=self.master_key_provider)
+        client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
+        plaintext, _header = client.decrypt(source=self.ciphertext, key_provider=self.master_key_provider)
         if plaintext != self.plaintext:
             raise ValueError("Decrypted plaintext does not match expected value for scenario '{}'".format(name))
 

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/encrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/encrypt.py
@@ -40,13 +40,14 @@ from awses_test_vectors.manifests.keys import KeysManifest
 from awses_test_vectors.manifests.master_key import MasterKeySpec, master_key_provider_from_master_key_specs
 
 try:
-    from aws_encryption_sdk.identifiers import AlgorithmSuite
+    from aws_encryption_sdk.identifiers import AlgorithmSuite, CommitmentPolicy
 except ImportError:
     from aws_encryption_sdk.identifiers import Algorithm as AlgorithmSuite
 
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from typing import Callable, Dict, IO, Iterable, Optional  # noqa pylint: disable=unused-import
+    from typing import IO, Callable, Dict, Iterable, Optional  # noqa pylint: disable=unused-import
+
     from awses_test_vectors.internal.mypy_types import (  # noqa pylint: disable=unused-import
         ENCRYPT_SCENARIO_SPEC,
         PLAINTEXTS_SPEC,
@@ -133,7 +134,8 @@ class MessageEncryptionTestScenario(object):
         :return: Decrypt test scenario that describes the generated scenario
         :rtype: MessageDecryptionTestScenario
         """
-        ciphertext, _header = aws_encryption_sdk.encrypt(
+        client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
+        ciphertext, _header = client.encrypt(
             source=self.plaintext,
             algorithm=self.algorithm,
             frame_length=self.frame_size,

--- a/test_vector_handlers/src/awses_test_vectors/manifests/keys.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/keys.py
@@ -25,13 +25,14 @@ from awses_test_vectors.internal.defaults import ENCODING
 from awses_test_vectors.internal.util import dictionary_validator, membership_validator, validate_manifest_type
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from typing import cast, Dict, Iterable, Optional  # noqa pylint: disable=unused-import
+    from typing import Dict, Iterable, Optional, cast  # noqa pylint: disable=unused-import
+
     from awses_test_vectors.internal.mypy_types import (  # noqa pylint: disable=unused-import
         AWS_KMS_KEY_SPEC,
-        MANUAL_KEY_SPEC,
         KEY_SPEC,
         KEYS_MANIFEST,
         MANIFEST_VERSION,
+        MANUAL_KEY_SPEC,
     )
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks

--- a/test_vector_handlers/src/awses_test_vectors/manifests/master_key.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/master_key.py
@@ -34,6 +34,7 @@ except ImportError:
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Iterable  # noqa pylint: disable=unused-import
+
     from awses_test_vectors.internal.mypy_types import MASTER_KEY_SPEC  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks

--- a/test_vector_handlers/tox.ini
+++ b/test_vector_handlers/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36,37}-awses_{1.3.3,1.3.max,latest},
+    py{27,34,35,36,37}-awses_{1.7.1,2.0.0,latest},
     # 1.2.0 and 1.2.max are being difficult because of attrs
     bandit, doc8, readme, docs,
     {flake8,pylint}{,-tests},
@@ -48,6 +48,8 @@ deps =
     -rtest/requirements.txt
     awses_1.3.3: -rcompatibility-requirements/1.3.3
     awses_1.3.max: -rcompatibility-requirements/1.3.max
+    awses_1.7.1: -rcompatibility-requirements/1.7.1
+    awses_2.0.0: -rcompatibility-requirements/2.0.0
     awses_latest: -rcompatibility-requirements/latest
 commands = {[testenv:base-command]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -343,11 +343,32 @@ deps =
     {[testenv:build]deps}
     twine
 passenv =
+    # Intentionally omit TWINE_REPOSITORY_URL from the passenv list,
+    # as this overrides other ways of setting the repository and could
+    # unexpectedly result in releasing to the wrong repo
     {[testenv]passenv} \
     TWINE_USERNAME \
     TWINE_PASSWORD
 commands =
     {[testenv:build]commands}
+
+[testenv:release-private]
+basepython = python3
+skip_install = true
+deps = {[testenv:release-base]deps}
+passenv =
+    {[testenv:release-base]passenv} \
+    TWINE_REPOSITORY_URL
+setenv =
+    # Explicitly set the URL as the env variable value, which will cause us to
+    # throw an error if the variable is not set. Otherwise, omission of the
+    # env variable could cause us to unintentionally upload to the wrong repo
+    TWINE_REPOSITORY_URL = {env:TWINE_REPOSITORY_URL}
+commands =
+    {[testenv:release-base]commands}
+    # Omitting an explicit repository will cause twine to use the repository
+    # specified in the environment variable
+    twine upload --skip-existing {toxinidir}/dist/*
 
 [testenv:test-release]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -345,11 +345,9 @@ deps =
 passenv =
     {[testenv]passenv} \
     TWINE_USERNAME \
-    TWINE_PASSWORD \
-    TWINE_REPOSITORY_URL
+    TWINE_PASSWORD
 commands =
     {[testenv:build]commands}
-    twine upload --skip-existing {toxinidir}/dist/*
 
 [testenv:test-release]
 basepython = python3
@@ -357,9 +355,8 @@ skip_install = true
 deps = {[testenv:release-base]deps}
 passenv =
     {[testenv:release-base]passenv}
-setenv =
-    TWINE_REPOSITORY_URL = https://test.pypi.org/legacy/
-commands = {[testenv:release-base]commands}
+commands =
+    twine upload --skip-existing --repository testpypi {toxinidir}/dist/*
 
 [testenv:release]
 basepython = python3
@@ -367,8 +364,5 @@ skip_install = true
 deps = {[testenv:release-base]deps}
 passenv =
     {[testenv:release-base]passenv}
-whitelist_externals = unset
 commands =
-    # Unsetting the TWINE_REPOSITORY_URL defaults twine to using production PyPI
-    unset TWINE_REPOSITORY_URL
-    {[testenv:release-base]commands}
+    twine upload --skip-existing --repository pypi {toxinidir}/dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -356,6 +356,7 @@ deps = {[testenv:release-base]deps}
 passenv =
     {[testenv:release-base]passenv}
 commands =
+    {[testenv:release-base]commands}
     twine upload --skip-existing --repository testpypi {toxinidir}/dist/*
 
 [testenv:release]
@@ -365,4 +366,5 @@ deps = {[testenv:release-base]deps}
 passenv =
     {[testenv:release-base]passenv}
 commands =
+    {[testenv:release-base]commands}
     twine upload --skip-existing --repository pypi {toxinidir}/dist/*


### PR DESCRIPTION
*Description of changes:*
- Add `commitment_policy` where it was missing from a docstring
- Update test vectors to use new 2.0 symbols. Note that longer term we'll need to figure out a better story around testing multiple versions of code and multiple versions of ciphertext formats. For now, I've just used the newest symbols and updated the environments to only use ESDK versions 1.7.1 and 2.0.0.
- Update decrypt_oracle to use new 2.0 symbols.
- Update commit hashes in CHANGELOG
- Small updates to tox release environments

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

