### PR TITLE
Update dependency on cryptography (2.x)

### DIFF
--- a/.github/workflows/ci_decrypt-oracle.yaml
+++ b/.github/workflows/ci_decrypt-oracle.yaml
@@ -41,7 +41,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-python@v1
           with:
-            python-version: 3.x
+            python-version: 3.8
         - run: |
             python -m pip install --upgrade pip
             pip install --upgrade -r ci-requirements.txt

--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.x
+          python-version: 3.8
       - run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r ci-requirements.txt

--- a/.github/workflows/ci_test-vector-handler.yaml
+++ b/.github/workflows/ci_test-vector-handler.yaml
@@ -76,7 +76,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-python@v1
           with:
-            python-version: 3.x
+            python-version: 3.8
         - run: |
             python -m pip install --upgrade pip
             pip install --upgrade -r ci-requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Required Prerequisites
 ======================
 
 * Python 2.7+ or 3.4+
-* cryptography >= 1.8.1
+* cryptography >= 2.5.0
 * boto3
 * attrs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3>=1.4.4
-cryptography>=1.8.1
+cryptography>=2.5.0
 attrs>=17.4.0
 wrapt>=1.10.11


### PR DESCRIPTION
*Description of changes:*
Changes in 2.0.x depend on behavior introduced in cryptography 2.5, so we need to correctly model our dependency.

*Additional testing:*
If I set the requirement to `~=2.4.2` we see failures due to how cryptography checks byte types. If I set the requirement to `~=2.5.0`, it passes.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

