### PR TITLE
chore: Update README section on using StrictAwsKmsKeyProvider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,10 @@ pre-existing instance of a ``botocore session`` to the ``StrictAwsKmsMasterKeyPr
 This latter option can be useful if you have an alternate way to store your AWS credentials or
 you want to reuse an existing instance of a botocore session in order to decrease startup costs.
 
-To create a ``StrictAwsKmsMasterKeyProvider`` you must provide one or more CMKs.
+To create a ``StrictAwsKmsMasterKeyProvider`` you must provide one or more CMKs. For providers that will only
+be used for encryption, you can use a key ARN or alias ARN. For providers that will be used for decryption, you
+must use the key ARN; aliases are not supported.
+
 If you configure the the ``StrictAwsKmsMasterKeyProvider`` with multiple CMKs, the `final message`_
 will include a copy of the data key encrypted by each configured CMK.
 

--- a/README.rst
+++ b/README.rst
@@ -132,8 +132,8 @@ This latter option can be useful if you have an alternate way to store your AWS 
 you want to reuse an existing instance of a botocore session in order to decrease startup costs.
 
 To create a ``StrictAwsKmsMasterKeyProvider`` you must provide one or more CMKs. For providers that will only
-be used for encryption, you can use a key ARN or alias ARN. For providers that will be used for decryption, you
-must use the key ARN; aliases are not supported.
+be used for encryption, you can use any valid `KMS key identifier`_. For providers that will be used for decryption, you
+must use the key ARN; key ids, alias names, and alias ARNs are not supported.
 
 If you configure the the ``StrictAwsKmsMasterKeyProvider`` with multiple CMKs, the `final message`_
 will include a copy of the data key encrypted by each configured CMK.
@@ -318,6 +318,7 @@ to your use-case in order to obtain peak performance.
 .. _GitHub: https://github.com/aws/aws-encryption-sdk-python/
 .. _AWS KMS: https://docs.aws.amazon.com/kms/latest/developerguide/overview.html
 .. _KMS customer master key (CMK): https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys
+.. _KMS key identifier: https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id
 .. _boto3 SDK: https://boto3.readthedocs.io/en/latest/
 .. _standard means by which boto3 locates credentials: https://boto3.readthedocs.io/en/latest/guide/configuration.html
 .. _final message: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/message-format.html

--- a/src/aws_encryption_sdk/key_providers/kms.py
+++ b/src/aws_encryption_sdk/key_providers/kms.py
@@ -237,7 +237,6 @@ class StrictAwsKmsMasterKeyProvider(BaseKMSMasterKeyProvider):
     ...     'arn:aws:kms:us-east-1:2222222222222:key/22222222-2222-2222-2222-222222222222',
     ...     'arn:aws:kms:us-east-1:3333333333333:key/33333333-3333-3333-3333-333333333333'
     ... ])
-    >>> kms_key_provider.add_master_key('arn:aws:kms:ap-northeast-1:4444444444444:alias/another-key')
 
     .. note::
         If no botocore_session is provided, the default botocore session will be used.

--- a/test_vector_handlers/compatibility-requirements/1.7.1
+++ b/test_vector_handlers/compatibility-requirements/1.7.1
@@ -1,2 +1,1 @@
 aws-encryption-sdk==1.7.1
-attrs<19.2.0

--- a/test_vector_handlers/compatibility-requirements/2.0.0
+++ b/test_vector_handlers/compatibility-requirements/2.0.0
@@ -1,2 +1,1 @@
 aws-encryption-sdk==2.0.0
-attrs<19.2.0


### PR DESCRIPTION
Be more explicit about the fact that, when using a StrictAwsKmsMasterKeyProvider, key aliases are not supported on decryption

*Issue #, if available:* https://github.com/aws/aws-encryption-sdk-python/issues/311

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
