### PR TITLE
chore: Clarify StrictAwsKmsMasterKeyProvider docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,11 @@ StrictAwsKmsMasterKeyProvider
 A ``StrictAwsKmsMasterKeyProvider`` is configured with an explicit list of AWS KMS
 CMKs with which to encrypt and decrypt data. On encryption, it encrypts the plaintext with all
 configured CMKs. On decryption, it only attempts to decrypt ciphertexts that have been wrapped
-with one of the configured CMKs.
+with a CMK that matches one of the configured CMK ARNs.
+
+To create a ``StrictAwsKmsMasterKeyProvider`` you must provide one or more CMKs. For providers that will only
+be used for encryption, you can use any valid `KMS key identifier`_. For providers that will be used for decryption, you
+must use the key ARN; key ids, alias names, and alias ARNs are not supported.
 
 Because the ``StrictAwsKmsMasterKeyProvider`` uses the `boto3 SDK`_ to interact with `AWS KMS`_,
 it requires AWS Credentials.
@@ -124,10 +128,6 @@ To provide these credentials, use the `standard means by which boto3 locates cre
 pre-existing instance of a ``botocore session`` to the ``StrictAwsKmsMasterKeyProvider``.
 This latter option can be useful if you have an alternate way to store your AWS credentials or
 you want to reuse an existing instance of a botocore session in order to decrease startup costs.
-
-To create a ``StrictAwsKmsMasterKeyProvider`` you must provide one or more CMKs. For providers that will only
-be used for encryption, you can use any valid `KMS key identifier`_. For providers that will be used for decryption, you
-must use the key ARN; key ids, alias names, and alias ARNs are not supported.
 
 If you configure the the ``StrictAwsKmsMasterKeyProvider`` with multiple CMKs, the `final message`_
 will include a copy of the data key encrypted by each configured CMK.

--- a/src/aws_encryption_sdk/key_providers/kms.py
+++ b/src/aws_encryption_sdk/key_providers/kms.py
@@ -231,7 +231,7 @@ class StrictAwsKmsMasterKeyProvider(BaseKMSMasterKeyProvider):
     should be used for encryption and decryption. On encryption, the plaintext will be encrypted with all configured
     master keys. On decryption, it only attempts to decrypt ciphertexts that have been wrapped with a CMK that
     matches one of the configured CMK ARNs. If the ciphertext is encrypted with a master key that was not
-    explicitly configured, decryption will fail. To create a Strict Aws Kms Master Key Provider you must provide
+    explicitly configured, decryption will fail. To create a StrictAwsKmsMasterKeyProvider you must provide
     one or more CMKs. For providers that will only be used for encryption, you can use any valid KMS key
     identifier. For providers that will be used for decryption, you must use the key ARN; key ids, alias names, and
     alias ARNs are not supported.

--- a/src/aws_encryption_sdk/key_providers/kms.py
+++ b/src/aws_encryption_sdk/key_providers/kms.py
@@ -228,9 +228,13 @@ class BaseKMSMasterKeyProvider(MasterKeyProvider):
 
 class StrictAwsKmsMasterKeyProvider(BaseKMSMasterKeyProvider):
     """Strict Master Key Provider for KMS. It is configured with an explicit list of AWS KMS master keys that
-    should be used for encryption in decryption. On encryption, the plaintext will be encrypted with all configured
-    master keys. On decryption, the ciphertext will be decrypted with the first master key that can decrypt. If the
-    ciphertext is encrypted with a master key that was not explicitly configured, decryption will fail.
+    should be used for encryption and decryption. On encryption, the plaintext will be encrypted with all configured
+    master keys. On decryption, it only attempts to decrypt ciphertexts that have been wrapped with a CMK that
+    matches one of the configured CMK ARNs. If the ciphertext is encrypted with a master key that was not
+    explicitly configured, decryption will fail. To create a Strict Aws Kms Master Key Provider you must provide
+    one or more CMKs. For providers that will only be used for encryption, you can use any valid KMS key
+    identifier. For providers that will be used for decryption, you must use the key ARN; key ids, alias names, and
+    alias ARNs are not supported.
 
     >>> import aws_encryption_sdk
     >>> kms_key_provider = aws_encryption_sdk.StrictAwsKmsMasterKeyProvider(key_ids=[


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* We've seen some confusion over the point that you must only use key ARNs when decrypting with the Strict KMS MK Provider. Attempting to clarify that in the code and docs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

