### PR TITLE
chore: Update dependency on boto3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Required Prerequisites
 
 * Python 2.7+ or 3.4+
 * cryptography >= 2.5.0
-* boto3
+* boto3 >= 1.10.0
 * attrs
 
 Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3>=1.4.4
+boto3>=1.10.0
 cryptography>=2.5.0
 attrs>=17.4.0
 wrapt>=1.10.11


### PR DESCRIPTION
*Description of changes:*
Now that we're passing key ids to KMS Decrypt operations, we need to make sure our boto version knows that Decrypt accepts KeyId as a parameter, otherwise client-side request validation fails. 

*Testing:*
Installed version 1.10 of boto3, confirmed that encrypt/decrypt operations succeed. Versions prior to 1.10 fail with `ParamValidationError: Unknown parameter in input: "KeyId", must be one of: CiphertextBlob, EncryptionContext, GrantTokens")`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

