### PR TITLE
chore: Mark pylint false positive

### DIFF
--- a/src/aws_encryption_sdk/internal/crypto/elliptic_curve.py
+++ b/src/aws_encryption_sdk/internal/crypto/elliptic_curve.py
@@ -123,7 +123,7 @@ def _ecc_decode_compressed_point(curve, compressed_point):
     y_order_map = {b"\x02": 0, b"\x03": 1}
     raw_x = compressed_point[1:]
     raw_x = to_bytes(raw_x)
-    x = int_from_bytes(raw_x, "big")
+    x = int_from_bytes(raw_x, "big") # pylint: disable=not-callable
     raw_y = compressed_point[0]
     # In Python3, bytes index calls return int values rather than strings
     if isinstance(raw_y, six.integer_types):

--- a/src/aws_encryption_sdk/internal/crypto/elliptic_curve.py
+++ b/src/aws_encryption_sdk/internal/crypto/elliptic_curve.py
@@ -123,7 +123,7 @@ def _ecc_decode_compressed_point(curve, compressed_point):
     y_order_map = {b"\x02": 0, b"\x03": 1}
     raw_x = compressed_point[1:]
     raw_x = to_bytes(raw_x)
-    x = int_from_bytes(raw_x, "big") # pylint: disable=not-callable
+    x = int_from_bytes(raw_x, "big")  # pylint: disable=not-callable
     raw_y = compressed_point[0]
     # In Python3, bytes index calls return int values rather than strings
     if isinstance(raw_y, six.integer_types):

--- a/test/unit/test_streaming_client_encryption_stream.py
+++ b/test/unit/test_streaming_client_encryption_stream.py
@@ -401,7 +401,7 @@ class TestEncryptionStream(object):
         )
         self.mock_source_stream.closed = False
         mock_stream.readline = MagicMock(return_value=sentinel.line)
-        test = mock_stream.next()
+        test = mock_stream.next() # pylint: disable=not-callable
         mock_stream.readline.assert_called_once_with()
         assert test is sentinel.line
 
@@ -415,7 +415,7 @@ class TestEncryptionStream(object):
         mock_stream.close()
 
         with pytest.raises(StopIteration):
-            mock_stream.next()
+            mock_stream.next() # pylint: disable=not-callable
 
     def test_next_source_stream_closed_and_buffer_empty(self):
         mock_stream = MockEncryptionStream(
@@ -428,7 +428,7 @@ class TestEncryptionStream(object):
         mock_stream.output_buffer = b""
 
         with pytest.raises(StopIteration):
-            mock_stream.next()
+            mock_stream.next() # pylint: disable=not-callable
 
     @patch("aws_encryption_sdk.streaming_client._EncryptionStream.closed", new_callable=PropertyMock)
     def test_iteration(self, mock_closed):

--- a/test/unit/test_streaming_client_encryption_stream.py
+++ b/test/unit/test_streaming_client_encryption_stream.py
@@ -401,7 +401,7 @@ class TestEncryptionStream(object):
         )
         self.mock_source_stream.closed = False
         mock_stream.readline = MagicMock(return_value=sentinel.line)
-        test = mock_stream.next() # pylint: disable=not-callable
+        test = mock_stream.next()  # pylint: disable=not-callable
         mock_stream.readline.assert_called_once_with()
         assert test is sentinel.line
 
@@ -415,7 +415,7 @@ class TestEncryptionStream(object):
         mock_stream.close()
 
         with pytest.raises(StopIteration):
-            mock_stream.next() # pylint: disable=not-callable
+            mock_stream.next()  # pylint: disable=not-callable
 
     def test_next_source_stream_closed_and_buffer_empty(self):
         mock_stream = MockEncryptionStream(
@@ -428,7 +428,7 @@ class TestEncryptionStream(object):
         mock_stream.output_buffer = b""
 
         with pytest.raises(StopIteration):
-            mock_stream.next() # pylint: disable=not-callable
+            mock_stream.next()  # pylint: disable=not-callable
 
     @patch("aws_encryption_sdk.streaming_client._EncryptionStream.closed", new_callable=PropertyMock)
     def test_iteration(self, mock_closed):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Marking pylint results as false positive.

It looks like the int_from_bytes pylint finding is related to the deprecation of int_from_bytes in cryptography 3.4. The code will still work, but will throw deprecation warnings. I'd like to mark this as a false positive now in order to keep CI clear while we determine how to best deal with that deprecation.

The reports from `test/unit/test_streaming_client_encryption_stream.py` also appear to be false positives. From static analysis it should be clear that MockEncryptingStream inherits from _EncryptionStream, which defines `next`: https://github.com/aws/aws-encryption-sdk-python/blob/master/src/aws_encryption_sdk/streaming_client.py#L304

I think that how we define the `next` hook for Python3 may be confusing the linter, though I'm not sure what recent change to pylint would have resulted in this: https://github.com/aws/aws-encryption-sdk-python/blob/master/src/aws_encryption_sdk/streaming_client.py#L319

Given that these tests are asserting various expected properties from running `next`, I'm confident that these are false positives.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

