### PR TITLE
chore: Add 'release' buildspecs for codebuild

### DIFF
--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -1,0 +1,28 @@
+version: 0.2
+
+env:
+  variables:
+    BRANCH: "master"
+  secrets-manager:
+    TWINE_USERNAME: PyPiAdmin:username 
+    TWINE_PASSWORD: PyPiAdmin:password
+
+phases:
+  install:
+    runtime-versions:
+      python: latest
+  build:
+    commands:
+      - pip install tox
+      - git checkout $BRANCH
+      - tox -e park
+      - tox -e release
+      - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
+      - cd busy-engineers-document-bucket/exercises/python/encryption-context-complete
+      - tox -e test
+
+
+batch:
+  fast-fail: false
+  build-list:
+    - identifier: prod_release

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -1,0 +1,25 @@
+version: 0.2
+
+env:
+  variables:
+    BRANCH: "master"
+  secrets-manager:
+    TWINE_USERNAME: TestPyPiCryptoTools:username 
+    TWINE_PASSWORD: TestPyPiCryptoTools:password
+
+phases:
+  install:
+    runtime-versions:
+      python: latest
+  build:
+    commands:
+      - pip install tox
+      - git checkout $BRANCH
+      - tox -e park
+      - tox -e test-release
+
+
+batch:
+  fast-fail: false
+  build-list:
+    - identifier: test_release


### PR DESCRIPTION
This is a step towards a more continuous release process. If this ends up being a productive path, we can expect to pull more validation into these codebuild specs.

*Testing*:
I've run CodeBuild builds against these specs and they succeed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

