### PR TITLE
chore: Explicitly override version when validating release

### DIFF
--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -19,6 +19,7 @@ phases:
       - tox -e release
       - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
       - cd busy-engineers-document-bucket/exercises/python/encryption-context-complete
+      - sed -i "s/aws_encryption_sdk/aws_encryption_sdk==$VERSION/" requirements-dev.txt
       - tox -e test
 
 

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
@@ -91,6 +91,7 @@ class MessageDecryptionTestScenario(object):
         description=None,  # type: Optional[str]
     ):  # noqa=D107
         # type: (...) -> None
+        """Set initial values for the test scenario."""
         # Workaround pending resolution of attrs/mypy interaction.
         # https://github.com/python/mypy/issues/2088
         # https://github.com/python-attrs/attrs/issues/215
@@ -200,6 +201,7 @@ class MessageDecryptionManifest(object):
         client_version=aws_encryption_sdk.__version__,  # type: Optional[str]
     ):  # noqa=D107
         # type: (...) -> None
+        """Set initial values for the manifest."""
         # Workaround pending resolution of attrs/mypy interaction.
         # https://github.com/python/mypy/issues/2088
         # https://github.com/python-attrs/attrs/issues/215

--- a/test_vector_handlers/src/awses_test_vectors/manifests/keys.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/keys.py
@@ -142,6 +142,7 @@ class ManualKeySpec(KeySpec):
         material,  # type: Iterable[str]
     ):  # noqa=D107
         # type: (...) -> None
+        """Set initial values for the ManualKeySpec."""
         # Workaround pending resolution of attrs/mypy interaction.
         # https://github.com/python/mypy/issues/2088
         # https://github.com/python-attrs/attrs/issues/215


### PR DESCRIPTION
Otherwise it just pulls down "latest", and with eventual consistency on PyPi
we might end up pulling down a previous version and not actually validating
our release.

This has the downside that, again due to eventual consistency, the new
version might not show up yet causing the build to fail. Since this build
is idempotent this is not the end of the world, but we may want to make
this more robust in the future.

*Testing*:
Confirmed that validation step fails if I provide a version that doesn't exist, and succeeds if I provide one that does exist.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

