### PR TITLE
chore: Fail build if code coverage is too low

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -57,3 +57,6 @@ batch:
       buildspec: codebuild/py38/awses_2.0.0.yml
     - identifier: py38_awses_latest
       buildspec: codebuild/py38/awses_latest.yml
+
+    - identifier: code_coverage
+      buildspec: codebuild/coverage/coverage.yml

--- a/codebuild/coverage/coverage.yml
+++ b/codebuild/coverage/coverage.yml
@@ -1,0 +1,14 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "coverage"
+
+phases:
+  install:
+    runtime-versions:
+      python: latest
+  build:
+    commands:
+      - pip install tox
+      - tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ branch = True
 
 [coverage:report]
 show_missing = True
+fail_under = 95
 
 [tool:pytest]
 log_level = DEBUG

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,12 @@ envlist =
 # test-release :: Builds dist files and uploads to testpypi pypirc profile.
 # release :: Builds dist files and uploads to pypi pypirc profile.
 
+# Reporting environments:
+#
+# coverage :: Runs code coverage, failing the build if coverage is below the configured threshold
+
 [testenv:base-command]
-commands = pytest --basetemp={envtmpdir} -l --cov aws_encryption_sdk {posargs}
+commands = pytest --basetemp={envtmpdir} -l {posargs}
 
 [testenv]
 passenv =
@@ -61,6 +65,10 @@ commands =
     examples: {[testenv:base-command]commands} examples/test/ -m examples
     all: {[testenv:base-command]commands} test/ examples/test/
     manual: {[testenv:base-command]commands}
+
+# Run code coverage on the unit tests
+[testenv:coverage]
+commands = {[testenv:base-command]commands} --cov aws_encryption_sdk test/ -m local
 
 # Verify that local tests work without environment variables present
 [testenv:nocmk]


### PR DESCRIPTION
*Description of changes:*
Remove code coverage from base python command, add a dedicated code coverage environment, as well as code build specs to run it.

If we have all test environments running code coverage and configure it to fail on low coverage, we run into issues with things like integration tests, which intentionally are not exhaustive in their coverage. Plus running coverage on every test isn't that useful without a mechanism to do something about it (hoping a human happens to look at the output doesn't count).

So, make code coverage a dedicated target, have it target unit tests, and set a high threshold.

See also: https://github.com/aws/aws-dynamodb-encryption-python/pull/153

*Testing:*

Building gives me:
```
Required test coverage of 95.0% reached. Total coverage: 98.46%
```
If I bump the threshold to 99, the build fails with:
```
FAIL Required test coverage of 99.0% not reached. Total coverage: 98.46%
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

