### PR TITLE
chore: Add validation to test release codebuild spec

### DIFF
--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -20,7 +20,7 @@ phases:
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then
-          echo "identifiers.py does not contain expected version string ${VERSION}, stopping"
+          echo "identifiers.py version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
   build:
@@ -31,8 +31,8 @@ phases:
 batch:
   fast-fail: true 
   build-graph:
-    - identifier: prod_release
-    - identifier: validate_release
+    - identifier: release_to_prod
+    - identifier: validate_prod_release
       depend-on:
         - prod_release
       buildspec: codebuild/release/validate.yml

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -9,21 +9,33 @@ env:
 
 phases:
   install:
-    runtime-versions:
-      python: latest
-  build:
     commands:
       - pip install tox
+      - pip install --upgrade pip
+    runtime-versions:
+      python: latest
+  pre_build:
+    commands:
       - git checkout $BRANCH
+      - CURRENT_COMMIT=$(git rev-parse --short HEAD)
+      - |
+        if expr "${CURRENT_COMMIT}" != ${COMMIT_ID}; then
+          echo "HEAD of repository commit (${CURRENT_COMMIT}) did not match expected commit (${COMMIT_ID}), stopping"
+          exit 1;
+        fi
+  build:
+    commands:
       - tox -e park
       - tox -e release
-      - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
-      - cd busy-engineers-document-bucket/exercises/python/encryption-context-complete
-      - sed -i "s/aws_encryption_sdk/aws_encryption_sdk==$VERSION/" requirements-dev.txt
-      - tox -e test
-
 
 batch:
-  fast-fail: false
-  build-list:
+  fast-fail: true 
+  build-graph:
     - identifier: prod_release
+    - identifier: validate_release
+      depend-on:
+        - prod_release
+      buildspec: codebuild/release/validate.yml
+      env:
+        variables:
+          PIP_INDEX_URL: https://pypi.python.org/simple/

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -34,7 +34,7 @@ batch:
     - identifier: release_to_prod
     - identifier: validate_prod_release
       depend-on:
-        - prod_release
+        - release_to_prod
       buildspec: codebuild/release/validate.yml
       env:
         variables:

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -16,11 +16,11 @@ phases:
       python: latest
   pre_build:
     commands:
-      - git checkout $BRANCH
-      - CURRENT_COMMIT=$(git rev-parse --short HEAD)
+      - git checkout $COMMIT_ID
+      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |
-        if expr "${CURRENT_COMMIT}" != ${COMMIT_ID}; then
-          echo "HEAD of repository commit (${CURRENT_COMMIT}) did not match expected commit (${COMMIT_ID}), stopping"
+        if expr ${FOUND_VERSION} != ${VERSION}; then
+          echo "identifiers.py does not contain expected version string ${VERSION}, stopping"
           exit 1;
         fi
   build:

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -35,7 +35,7 @@ batch:
     - identifier: release_to_staging
     - identifier: validate_staging_release
       depend-on:
-        - test_release
+        - release_to_staging
       buildspec: codebuild/release/validate.yml
       env:
         variables:

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -20,7 +20,7 @@ phases:
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then
-          echo "identifiers.py does not contain expected version string ${VERSION}, stopping"
+          echo "identifiers.py version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
   build:
@@ -32,8 +32,8 @@ phases:
 batch:
   fast-fail: true
   build-graph:
-    - identifier: test_release
-    - identifier: validate_test_release
+    - identifier: release_to_staging
+    - identifier: validate_staging_release
       depend-on:
         - test_release
       buildspec: codebuild/release/validate.yml

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -16,11 +16,11 @@ phases:
       python: latest
   pre_build:
     commands:
-      - git checkout $BRANCH
-      - CURRENT_COMMIT=$(git rev-parse --short HEAD)
+      - git checkout $COMMIT_ID
+      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |
-        if expr "${CURRENT_COMMIT}" != ${COMMIT_ID}; then
-          echo "HEAD of repository commit (${CURRENT_COMMIT}) did not match expected commit (${COMMIT_ID}), stopping"
+        if expr ${FOUND_VERSION} != ${VERSION}; then
+          echo "identifiers.py does not contain expected version string ${VERSION}, stopping"
           exit 1;
         fi
   build:

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -9,17 +9,35 @@ env:
 
 phases:
   install:
-    runtime-versions:
-      python: latest
-  build:
     commands:
       - pip install tox
+      - pip install --upgrade pip
+    runtime-versions:
+      python: latest
+  pre_build:
+    commands:
       - git checkout $BRANCH
+      - CURRENT_COMMIT=$(git rev-parse --short HEAD)
+      - |
+        if expr "${CURRENT_COMMIT}" != ${COMMIT_ID}; then
+          echo "HEAD of repository commit (${CURRENT_COMMIT}) did not match expected commit (${COMMIT_ID}), stopping"
+          exit 1;
+        fi
+  build:
+    commands:
       - tox -e park
       - tox -e test-release
 
 
 batch:
-  fast-fail: false
-  build-list:
+  fast-fail: true
+  build-graph:
     - identifier: test_release
+    - identifier: validate_test_release
+      depend-on:
+        - test_release
+      buildspec: codebuild/release/validate.yml
+      env:
+        variables:
+          PIP_INDEX_URL: https://test.pypi.org/simple/
+          PIP_EXTRA_INDEX_URL: https://pypi.python.org/simple/

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -1,0 +1,16 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - pip install tox
+    runtime-versions:
+      python: latest
+  pre_build:
+    commands:
+      - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
+      - cd busy-engineers-document-bucket/exercises/python/encryption-context-complete
+      - sed -i "s/aws_encryption_sdk/aws_encryption_sdk==$VERSION/" requirements-dev.txt
+  build:
+    commands:
+      - tox -e test


### PR DESCRIPTION
*Description of changes:*

Now the test release validation does the same checks as the prod release (running the sample application against the new version), but targeting testpypi. To support this I've also refactored out the validation steps into a dedicated spec so both the prod and test specs can depend on it.

*Testing:*
Prod and test releases succeed (without any version uploaded, because it hasn't changed) when I give them the correct version and commit.

When I give a bad commit, we fail to checkout the branch and stop.

When I give a good commit but bad version, we detect that the authoritative version in `identifiers.py` does not match the requested version and stop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

