### PR TITLE
chore: Update README to correctly show supported python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ aws-encryption-sdk
    :target: https://pypi.python.org/pypi/aws-encryption-sdk
    :alt: Latest Version
 
-.. image:: https://img.shields.io/pypi/pyversions/aws-encryption-sdk-cli.svg
+.. image:: https://img.shields.io/pypi/pyversions/aws-encryption-sdk.svg
    :target: https://pypi.python.org/pypi/aws-encryption-sdk
    :alt: Supported Python Versions
 


### PR DESCRIPTION
*Description of changes:*
We had a copy/paste error and were point at the CLI

*Testing:*
New link shows the right python version support: https://img.shields.io/pypi/pyversions/aws-encryption-sdk.svg

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

