### PR TITLE
fix: Downgrade decrypt oracle commitment policy

### DIFF
--- a/decrypt_oracle/test/integration/integration_test_utils.py
+++ b/decrypt_oracle/test/integration/integration_test_utils.py
@@ -29,7 +29,7 @@ AWS_KMS_KEY_ID = "AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID"
 _KMS_MKP = None
 _ENDPOINT = None
 
-CLIENT = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
+CLIENT = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
 
 
 def decrypt_endpoint() -> Text:


### PR DESCRIPTION
The policy set earlier doesn’t exist in the 1.x branch. and this value should be perfectly equivalent since the decrypt oracle only decrypts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

