### PR TITLE
chore: Add readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+   configuration: doc/conf.py
+
+# Don't need to build documentation for test vectors or any other
+# sub modules
+submodules:
+  exclude: all


### PR DESCRIPTION
*Description of changes:*
This is primarily to add explicit ignoring of submodules, which have broken our doc builds: https://readthedocs.org/projects/aws-encryption-sdk-python/builds/13981651/

Note that we could also fix the specific error above by moving to the public test vectors module, but more generally this submodule is for testing and doesn't need to be included in documentation.

*Testing:*
Not really sure how to test this, since it relates to readthedocs integration.

My source material is:
https://sphinx-with-submodules.readthedocs.io/en/latest/ and https://docs.readthedocs.io/en/stable/config-file/v2.html#submodules 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

