### PR TITLE
chore: Further fixes to readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,3 +13,10 @@ sphinx:
 # sub modules
 submodules:
   exclude: all
+
+python:
+  version: 3.8
+  install:
+    - requirements: requirements.txt
+    - method: setuptools
+      path: .


### PR DESCRIPTION
*Description of changes:*
Recent build fails to import modules: https://readthedocs.org/projects/aws-encryption-sdk-python/builds/13990608/

I was able to reproduce locally by repeating the commands from the above, and it looks like some defaults are not set correctly for us. 

*Testing:*
When I simulate the commands from the above build, but add the commands to install requirements and local package, build succeeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

