### PR TITLE
chore: Fix CI

### DIFF
--- a/decrypt_oracle/setup.py
+++ b/decrypt_oracle/setup.py
@@ -10,7 +10,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 def read(*args):
     """Read complete file contents."""
-    return open(os.path.join(HERE, *args)).read()
+    return open(os.path.join(HERE, *args)).read() # pylint: disable=consider-using-with
 
 
 def get_version():

--- a/decrypt_oracle/setup.py
+++ b/decrypt_oracle/setup.py
@@ -10,7 +10,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 def read(*args):
     """Read complete file contents."""
-    return open(os.path.join(HERE, *args)).read() # pylint: disable=consider-using-with
+    return open(os.path.join(HERE, *args)).read()  # pylint: disable=consider-using-with
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 def read(*args):
     """Reads complete file contents."""
-    return open(os.path.join(HERE, *args)).read()
+    return open(os.path.join(HERE, *args)).read() # pylint: disable=consider-using-with
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 def read(*args):
     """Reads complete file contents."""
-    return open(os.path.join(HERE, *args)).read() # pylint: disable=consider-using-with
+    return open(os.path.join(HERE, *args)).read()  # pylint: disable=consider-using-with
 
 
 def get_version():

--- a/src/aws_encryption_sdk/internal/utils/streams.py
+++ b/src/aws_encryption_sdk/internal/utils/streams.py
@@ -43,6 +43,7 @@ class TeeStream(ObjectProxy):
     :param tee: Stream to copy read bytes into.
     :type tee: io.BaseIO
     """
+
     # Prime ObjectProxy's attributes to allow setting in init.
     __tee = None  # pylint: disable=unused-private-member
 

--- a/src/aws_encryption_sdk/internal/utils/streams.py
+++ b/src/aws_encryption_sdk/internal/utils/streams.py
@@ -43,8 +43,8 @@ class TeeStream(ObjectProxy):
     :param tee: Stream to copy read bytes into.
     :type tee: io.BaseIO
     """
-
-    __tee = None  # Prime ObjectProxy's attributes to allow setting in init.
+    # Prime ObjectProxy's attributes to allow setting in init.
+    __tee = None  # pylint: disable=unused-private-member
 
     def __init__(self, wrapped, tee):
         """Creates the local tee stream."""

--- a/test/integration/test_kat_commitment.py
+++ b/test/integration/test_kat_commitment.py
@@ -50,7 +50,7 @@ if not os.path.isdir(root_dir):
 base_dir = os.path.join(root_dir, "test", "resources")
 file_path = os.path.join(base_dir, FILE_NAME)
 
-test_str = open(file_path, "r").read()
+test_str = open(file_path, "r").read()  # pylint: disable=consider-using-with
 test_json = json.loads(test_str)
 kat_tests = test_json["tests"]
 

--- a/test/unit/test_caches_crypto_cache_entry.py
+++ b/test/unit/test_caches_crypto_cache_entry.py
@@ -32,7 +32,7 @@ _VALID_KWARGS = {
 }
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_time(mocker):
     mocker.patch.object(aws_encryption_sdk.caches.time, "time")
 

--- a/test/unit/test_caches_local.py
+++ b/test/unit/test_caches_local.py
@@ -132,7 +132,7 @@ def test_try_to_evict_one_entry_entry_valid():
     cache._lre_deque.appendleft.assert_called_once_with(mock_reference)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_try_to_evict_one_entry(mocker):
     mocker.patch.object(LocalCryptoMaterialsCache, "_try_to_evict_one_entry")
     yield LocalCryptoMaterialsCache._try_to_evict_one_entry
@@ -165,7 +165,7 @@ def test_prune(patch_try_to_evict_one_entry):
     patch_try_to_evict_one_entry.assert_has_calls((call(), call()))
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_prune(mocker):
     mocker.patch.object(LocalCryptoMaterialsCache, "_prune")
     yield LocalCryptoMaterialsCache._prune
@@ -183,19 +183,19 @@ def test_add_value_to_cache(patch_prune):
     patch_prune.assert_called_once_with()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_try_to_evict_some_entries(mocker):
     mocker.patch.object(LocalCryptoMaterialsCache, "_try_to_evict_some_entries")
     yield LocalCryptoMaterialsCache._try_to_evict_some_entries
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_add_value_to_cache(mocker):
     mocker.patch.object(LocalCryptoMaterialsCache, "_add_value_to_cache")
     yield LocalCryptoMaterialsCache._add_value_to_cache
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_crypto_cache_entry(mocker):
     mocker.patch.object(aws_encryption_sdk.caches.local, "CryptoMaterialsCacheEntry")
     yield aws_encryption_sdk.caches.local.CryptoMaterialsCacheEntry
@@ -252,7 +252,7 @@ def test_remove_success():
     assert sentinel.value not in cache._cache
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_remove(mocker):
     mocker.patch.object(LocalCryptoMaterialsCache, "remove")
     yield LocalCryptoMaterialsCache.remove
@@ -291,7 +291,7 @@ def test_get_single_entry_cache_hit_valid():
     assert test is mock_entry
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_get_single_entry(mocker):
     mocker.patch.object(LocalCryptoMaterialsCache, "_get_single_entry")
     yield LocalCryptoMaterialsCache._get_single_entry

--- a/test/unit/test_crypto_authentication_signer.py
+++ b/test/unit/test_crypto_authentication_signer.py
@@ -24,37 +24,37 @@ from .test_crypto import VALUES
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_default_backend(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "default_backend")
     yield aws_encryption_sdk.internal.crypto.authentication.default_backend
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_serialization(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "serialization")
     yield aws_encryption_sdk.internal.crypto.authentication.serialization
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_ecc_encode_compressed_point(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "_ecc_encode_compressed_point")
     yield aws_encryption_sdk.internal.crypto.authentication._ecc_encode_compressed_point
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_ecc_static_length_signature(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "_ecc_static_length_signature")
     yield aws_encryption_sdk.internal.crypto.authentication._ecc_static_length_signature
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_base64(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "base64")
     yield aws_encryption_sdk.internal.crypto.authentication.base64
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_build_hasher(mocker):
     mocker.patch.object(Signer, "_build_hasher")
     yield Signer._build_hasher

--- a/test/unit/test_crypto_authentication_verifier.py
+++ b/test/unit/test_crypto_authentication_verifier.py
@@ -24,49 +24,49 @@ from .test_crypto import VALUES
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_default_backend(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "default_backend")
     yield aws_encryption_sdk.internal.crypto.authentication.default_backend
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_serialization(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "serialization")
     yield aws_encryption_sdk.internal.crypto.authentication.serialization
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_ecc_public_numbers_from_compressed_point(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "_ecc_public_numbers_from_compressed_point")
     yield aws_encryption_sdk.internal.crypto.authentication._ecc_public_numbers_from_compressed_point
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_ec(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "ec")
     yield aws_encryption_sdk.internal.crypto.authentication.ec
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_prehashed(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "Prehashed")
     yield aws_encryption_sdk.internal.crypto.authentication.Prehashed
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_base64(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "base64")
     yield aws_encryption_sdk.internal.crypto.authentication.base64
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_build_hasher(mocker):
     mocker.patch.object(Verifier, "_build_hasher")
     yield Verifier._build_hasher
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_set_signature_type(mocker):
     mocker.patch.object(Verifier, "_set_signature_type")
     yield Verifier._set_signature_type

--- a/test/unit/test_crypto_data_keys.py
+++ b/test/unit/test_crypto_data_keys.py
@@ -15,18 +15,18 @@ import pytest
 from mock import MagicMock, sentinel
 from pytest_mock import mocker  # noqa pylint: disable=unused-import
 
-import aws_encryption_sdk.internal.crypto.data_keys as data_keys
+from aws_encryption_sdk.internal.crypto import data_keys
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_default_backend(mocker):
     mocker.patch.object(data_keys, "default_backend")
     yield data_keys.default_backend
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_struct(mocker):
     mocker.patch.object(data_keys, "struct")
     yield data_keys.struct

--- a/test/unit/test_crypto_elliptic_curve.py
+++ b/test/unit/test_crypto_elliptic_curve.py
@@ -36,55 +36,55 @@ from .test_crypto import VALUES
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_default_backend(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.elliptic_curve, "default_backend")
     yield aws_encryption_sdk.internal.crypto.elliptic_curve.default_backend
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_ec(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.elliptic_curve, "ec")
     yield aws_encryption_sdk.internal.crypto.elliptic_curve.ec
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_pow(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.elliptic_curve, "pow")
     yield aws_encryption_sdk.internal.crypto.elliptic_curve.pow
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_encode_dss_signature(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.elliptic_curve, "encode_dss_signature")
     yield aws_encryption_sdk.internal.crypto.elliptic_curve.encode_dss_signature
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_decode_dss_signature(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.elliptic_curve, "decode_dss_signature")
     yield aws_encryption_sdk.internal.crypto.elliptic_curve.decode_dss_signature
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_ecc_decode_compressed_point(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.elliptic_curve, "_ecc_decode_compressed_point")
     yield aws_encryption_sdk.internal.crypto.elliptic_curve._ecc_decode_compressed_point
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_verify_interface(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.elliptic_curve, "verify_interface")
     yield aws_encryption_sdk.internal.crypto.elliptic_curve.verify_interface
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_ecc_curve_parameters(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.elliptic_curve, "_ECC_CURVE_PARAMETERS")
     yield aws_encryption_sdk.internal.crypto.elliptic_curve._ECC_CURVE_PARAMETERS
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_prehashed(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.elliptic_curve, "Prehashed")
     yield aws_encryption_sdk.internal.crypto.elliptic_curve.Prehashed

--- a/test/unit/test_crypto_encryption_decryptor.py
+++ b/test/unit/test_crypto_encryption_decryptor.py
@@ -21,19 +21,19 @@ from aws_encryption_sdk.internal.crypto.encryption import Decryptor, decrypt
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_default_backend(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.encryption, "default_backend")
     yield aws_encryption_sdk.internal.crypto.encryption.default_backend
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_cipher(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.encryption, "Cipher")
     yield aws_encryption_sdk.internal.crypto.encryption.Cipher
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_decryptor(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.encryption, "Decryptor")
     yield aws_encryption_sdk.internal.crypto.encryption.Decryptor

--- a/test/unit/test_crypto_encryption_encryptor.py
+++ b/test/unit/test_crypto_encryption_encryptor.py
@@ -22,19 +22,19 @@ from aws_encryption_sdk.internal.structures import EncryptedData
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_default_backend(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.encryption, "default_backend")
     yield aws_encryption_sdk.internal.crypto.encryption.default_backend
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_cipher(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.encryption, "Cipher")
     yield aws_encryption_sdk.internal.crypto.encryption.Cipher
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_encryptor(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.encryption, "Encryptor")
     yield aws_encryption_sdk.internal.crypto.encryption.Encryptor

--- a/test/unit/test_crypto_prehashing_authenticator.py
+++ b/test/unit/test_crypto_prehashing_authenticator.py
@@ -23,37 +23,37 @@ from aws_encryption_sdk.internal.crypto.authentication import _PrehashingAuthent
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_set_signature_type(mocker):
     mocker.patch.object(_PrehashingAuthenticator, "_set_signature_type")
     yield _PrehashingAuthenticator._set_signature_type
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_build_hasher(mocker):
     mocker.patch.object(_PrehashingAuthenticator, "_build_hasher")
     yield _PrehashingAuthenticator._build_hasher
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_cryptography_utils_verify_interface(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "verify_interface")
     yield aws_encryption_sdk.internal.crypto.authentication.verify_interface
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_cryptography_ec(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "ec")
     yield aws_encryption_sdk.internal.crypto.authentication.ec
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_cryptography_hashes(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "hashes")
     yield aws_encryption_sdk.internal.crypto.authentication.hashes
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_cryptography_default_backend(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.authentication, "default_backend")
     yield aws_encryption_sdk.internal.crypto.authentication.default_backend

--- a/test/unit/test_crypto_wrapping_keys.py
+++ b/test/unit/test_crypto_wrapping_keys.py
@@ -26,43 +26,43 @@ from .test_crypto import VALUES
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_default_backend(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.wrapping_keys, "default_backend")
     yield aws_encryption_sdk.internal.crypto.wrapping_keys.default_backend
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_serialization(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.wrapping_keys, "serialization")
     yield aws_encryption_sdk.internal.crypto.wrapping_keys.serialization
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_derive_data_encryption_key(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.wrapping_keys, "derive_data_encryption_key")
     yield aws_encryption_sdk.internal.crypto.wrapping_keys.derive_data_encryption_key
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_urandom(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.wrapping_keys.os, "urandom")
     yield aws_encryption_sdk.internal.crypto.wrapping_keys.os.urandom
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_serialize_encryption_context(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.wrapping_keys, "serialize_encryption_context")
     yield aws_encryption_sdk.internal.crypto.wrapping_keys.serialize_encryption_context
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_encrypt(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.wrapping_keys, "encrypt")
     yield aws_encryption_sdk.internal.crypto.wrapping_keys.encrypt
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_decrypt(mocker):
     mocker.patch.object(aws_encryption_sdk.internal.crypto.wrapping_keys, "decrypt")
     yield aws_encryption_sdk.internal.crypto.wrapping_keys.decrypt

--- a/test/unit/test_material_managers_caching.py
+++ b/test/unit/test_material_managers_caching.py
@@ -64,7 +64,7 @@ def test_attrs_fail(invalid_kwargs):
         build_ccmm(**invalid_kwargs)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_uuid4(mocker):
     mocker.patch.object(aws_encryption_sdk.materials_managers.caching.uuid, "uuid4")
     yield aws_encryption_sdk.materials_managers.caching.uuid.uuid4
@@ -203,25 +203,25 @@ def test_cache_entry_has_exceeded_limits(mocker, too_old, too_many_messages, too
         assert not test
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_crypto_cache_entry_hints(mocker):
     mocker.patch.object(aws_encryption_sdk.materials_managers.caching, "CryptoMaterialsCacheEntryHints")
     yield aws_encryption_sdk.materials_managers.caching.CryptoMaterialsCacheEntryHints
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_cache_entry_has_exceeded_limits(mocker):
     mocker.patch.object(CachingCryptoMaterialsManager, "_cache_entry_has_exceeded_limits")
     yield CachingCryptoMaterialsManager._cache_entry_has_exceeded_limits
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_encryption_materials_request(mocker):
     mocker.patch.object(aws_encryption_sdk.materials_managers.caching, "EncryptionMaterialsRequest")
     yield aws_encryption_sdk.materials_managers.caching.EncryptionMaterialsRequest
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_build_encryption_materials_cache_key(mocker):
     mocker.patch.object(aws_encryption_sdk.materials_managers.caching, "build_encryption_materials_cache_key")
     yield aws_encryption_sdk.materials_managers.caching.build_encryption_materials_cache_key
@@ -246,7 +246,7 @@ def test_should_cache_encryption_request(plaintext_length, algorithm_provided, a
         assert not ccmm._should_cache_encryption_request(mock_request)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_should_cache_encryption_request(mocker):
     mocker.patch.object(CachingCryptoMaterialsManager, "_should_cache_encryption_request")
     CachingCryptoMaterialsManager._should_cache_encryption_request.return_value = True
@@ -381,13 +381,13 @@ def test_get_encryption_materials_cache_miss_algorithm_not_safe_to_cache(
     assert test is ccmm.backing_materials_manager.get_encryption_materials.return_value
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_build_decryption_materials_cache_key(mocker):
     mocker.patch.object(aws_encryption_sdk.materials_managers.caching, "build_decryption_materials_cache_key")
     yield aws_encryption_sdk.materials_managers.caching.build_decryption_materials_cache_key
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_cache_entry_is_too_old(mocker):
     mocker.patch.object(CachingCryptoMaterialsManager, "_cache_entry_is_too_old")
     return CachingCryptoMaterialsManager._cache_entry_is_too_old

--- a/test_vector_handlers/setup.py
+++ b/test_vector_handlers/setup.py
@@ -10,7 +10,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 def read(*args):
     """Read complete file contents."""
-    return open(os.path.join(HERE, *args)).read()
+    return open(os.path.join(HERE, *args)).read() # pylint: disable=consider-using-with
 
 
 def get_version():

--- a/test_vector_handlers/setup.py
+++ b/test_vector_handlers/setup.py
@@ -10,7 +10,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 def read(*args):
     """Read complete file contents."""
-    return open(os.path.join(HERE, *args)).read() # pylint: disable=consider-using-with
+    return open(os.path.join(HERE, *args)).read()  # pylint: disable=consider-using-with
 
 
 def get_version():


### PR DESCRIPTION
*Description of changes:*
Primarily some pylint ignores for things we don't care about in setup or test files.

Also fixes a bunch of pylint fixture deprecation warnings. Previously we had ~60 of these:

```
test/unit/test_material_managers_caching.py:391
  /Users/farleyb/workspace/esdk/python/aws-encryption-sdk-python/test/unit/test_material_managers_caching.py:391:
 PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.