### PR TITLE
chore: Manually install py36 in CI

### DIFF
--- a/codebuild/py36/awses_local.yml
+++ b/codebuild/py36/awses_local.yml
@@ -20,6 +20,8 @@ phases:
       python: latest
   build:
     commands:
-      - pip install tox
+      - pyenv install 3.6.12
+      - pyenv local 3.6.12
+      - pip install tox tox-pyenv
       - cd test_vector_handlers
       - tox

--- a/codebuild/py36/examples.yml
+++ b/codebuild/py36/examples.yml
@@ -18,5 +18,7 @@ phases:
       python: latest
   build:
     commands:
-      - pip install tox
+      - pyenv install 3.6.12
+      - pyenv local 3.6.12
+      - pip install tox tox-pyenv
       - tox

--- a/codebuild/py36/integ.yml
+++ b/codebuild/py36/integ.yml
@@ -18,5 +18,7 @@ phases:
       python: latest
   build:
     commands:
-      - pip install tox
+      - pyenv install 3.6.12
+      - pyenv local 3.6.12
+      - pip install tox tox-pyenv
       - tox


### PR DESCRIPTION
*Description of changes:*
We're not deprecating py36 for a while, and turns out we need to manually install it in codebuild now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

