### PR TITLE
chore: update readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ submodules:
 python:
   version: 3.8
   install:
-    - requirements: requirements.txt
+    - requirements: doc/requirements.txt
     - method: setuptools
       path: .

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>=1.3.0
-sphinx_rtd_theme
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0


### PR DESCRIPTION
*Description of changes:*
Fix RTD config to point to correct requirements. Also pin dependencies so we have reproducible builds.

See failing builds here: https://readthedocs.org/projects/aws-encryption-sdk-python/builds/15218410/

And known issue here: https://github.yuuza.net/sphinx-doc/sphinx/issues/9727

*Testing:*
I couldn't precisely reproduce this issue because it seems to be specific to how RTD configures its environment (in our case, pulling in a sphinx dependency < 2). That said, when I locally run the sphinx build to create docs (which specifies sphinx>1.3.0) it succeeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
