### PR TITLE
chore: pin dependencies and enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "mainline-1.x"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "mainline-2.x"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,3 @@ boto3==1.20.24
 cryptography==36.0.1
 attrs==21.2.0
 wrapt==1.13.3
-
-bandit==1.7.1
-doc8==0.10.1
-flake8==4.0.1
-pylint==2.12.2
-black==21.12b0
-isort==5.10.1
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,12 @@
-boto3>=1.10.0
-cryptography>=2.5.0
-attrs>=17.4.0
-wrapt>=1.10.11
+boto3==1.20.24
+cryptography==36.0.1
+attrs==21.2.0
+wrapt==1.13.3
+
+bandit==1.7.1
+doc8==0.10.1
+flake8==4.0.1
+pylint==2.12.2
+black==21.12b0
+isort==5.10.1
+

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,10 @@ mock==4.0.0
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-mock==3.6.0
+
+bandit==1.7.1
+doc8==0.10.1
+flake8==4.0.1
+pylint==2.12.2
+black==21.12b0
+isort==5.10.1

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
-mock
-pytest>=3.3.1
-pytest-cov
-pytest-mock
+mock==4.0.0
+pytest==6.2.0
+pytest-cov==3.0.0
+pytest-mock==3.6.0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
 mock==4.0.0
-pytest==6.2.0
+pytest==6.2.5
 pytest-cov==3.0.0
 pytest-mock==3.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -259,7 +259,7 @@ commands = python setup.py check -r -s
 [testenv:bandit]
 basepython = python3
 deps = 
-    bandit>=1.5.1
+    bandit
 commands = bandit -r src/aws_encryption_sdk/
 
 # Prone to false positives: only run independently


### PR DESCRIPTION
*Description of changes:*
Pins the following dependencies:
`boto3, cryptography, attrs, wrapt`
`mock, pytest, pytest-cov, pytest-mock, bandit, doc8, flake8, pylint, black, isort`

Why were those versions picked? 
I picked these versions from the last successful github actions workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

