### PR TITLE
chore: Pin dependencies for linters

### DIFF
--- a/dev_requirements/linter-requirements.txt
+++ b/dev_requirements/linter-requirements.txt
@@ -1,0 +1,14 @@
+bandit==1.7.0
+black==21.12b0
+doc8==0.10.1
+flake8==4.0.1
+flake8-bugbear==21.11.29
+flake8-docstrings==1.6.0
+flake8-print==4.0.0
+isort==5.10.1
+pyflakes==2.4.0
+pylint==2.12.2
+readme_renderer==32.0
+seed-isort-config==2.2.0
+vulture==2.3
+sphinx==4.3.2

--- a/test/unit/test_encryption_context.py
+++ b/test/unit/test_encryption_context.py
@@ -189,4 +189,4 @@ class TestEncryptionContext(object):
         test = aws_encryption_sdk.internal.formatting.encryption_context.deserialize_encryption_context(
             serialized_encryption_context=b""
         )
-        assert test == {}
+        assert not test

--- a/tox.ini
+++ b/tox.ini
@@ -149,15 +149,13 @@ commands =
 [testenv:flake8-tests]
 basepython = {[testenv:flake8]basepython}
 deps =
-    flake8
-    # https://github.com/JBKahn/flake8-print/pull/30
-    flake8-print>=3.1.0
+    -rdev_requirements/linter-requirements.txt
 commands =
     flake8 \
         # Ignore F811 redefinition errors in tests (breaks with pytest-mock use)
         # E203 is not PEP8 compliant https://github.com/ambv/black#slices
         # W503 is not PEP8 compliant https://github.com/ambv/black#line-breaks--binary-operators
-        --ignore F811,E203,W503 \
+        --ignore F811,E203,W503,D \
         test/
 
 [testenv:flake8-examples]
@@ -176,8 +174,7 @@ commands =
 basepython = python3
 deps =
     {[testenv]deps}
-    pyflakes
-    pylint
+    -rdev_requirements/linter-requirements.txt
 commands =
     pylint \
         --rcfile=src/pylintrc \
@@ -205,7 +202,7 @@ commands =
 [testenv:blacken-src]
 basepython = python3
 deps =
-    black
+    -rdev_requirements/linter-requirements.txt
 commands =
     black --line-length 120 \
         src/aws_encryption_sdk/ \
@@ -232,12 +229,12 @@ commands =
 
 [testenv:isort-seed]
 basepython = python3
-deps = seed-isort-config
+deps = -rdev_requirements/linter-requirements.txt
 commands = seed-isort-config
 
 [testenv:isort]
 basepython = python3
-deps = isort
+deps = -rdev_requirements/linter-requirements.txt
 commands = isort -rc \
     src \
     test \
@@ -264,25 +261,23 @@ commands =
 [testenv:doc8]
 basepython = python3
 deps =
-    sphinx
-    doc8
+    -rdev_requirements/linter-requirements.txt
 commands = doc8 doc/index.rst README.rst CHANGELOG.rst
 
 [testenv:readme]
 basepython = python3
-deps = readme_renderer
+deps = -rdev_requirements/linter-requirements.txt
 commands = python setup.py check -r -s
 
 [testenv:bandit]
 basepython = python3
-deps = 
-    bandit>=1.5.1
+deps = -rdev_requirements/linter-requirements.txt
 commands = bandit -r src/aws_encryption_sdk/
 
 # Prone to false positives: only run independently
 [testenv:vulture]
 basepython = python3
-deps = vulture
+deps = -rdev_requirements/linter-requirements.txt
 commands = vulture src/aws_encryption_sdk/
 
 [testenv:linters]

--- a/tox.ini
+++ b/tox.ini
@@ -155,6 +155,7 @@ commands =
         # Ignore F811 redefinition errors in tests (breaks with pytest-mock use)
         # E203 is not PEP8 compliant https://github.com/ambv/black#slices
         # W503 is not PEP8 compliant https://github.com/ambv/black#line-breaks--binary-operators
+        # D is for Documentation. We do not care if Test classes and their methods have docstrings
         --ignore F811,E203,W503,D \
         test/
 


### PR DESCRIPTION
Pin dependencies for linters to minimize broken builds on old branch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

