### PR TITLE
chore: remove dependabot from old branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,20 +6,6 @@ updates:
     schedule:
       interval: "daily"
 
-  # mainline-1.x
-  - package-ecosystem: "pip"
-    directory: "/dev_requirements"
-    schedule:
-      interval: "daily"
-    target-branch: "mainline-1.x"
-
-  # mainline-2.x
-  - package-ecosystem: "pip"
-    directory: "/dev_requirements"
-    schedule:
-      interval: "daily"
-    target-branch: "mainline-2.x"
-
   # Github Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

