### PR TITLE
chore: checkout corresponding branch instead of commit

### DIFF
--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    BRANCH: "master"
+    BRANCH: "mainline-2.x"
   secrets-manager:
     TWINE_USERNAME: PyPiAdmin:username 
     TWINE_PASSWORD: PyPiAdmin:password
@@ -16,7 +16,7 @@ phases:
       python: latest
   pre_build:
     commands:
-      - git checkout $COMMIT_ID
+      - git checkout $BRANCH
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -16,6 +16,7 @@ phases:
       python: latest
   pre_build:
     commands:
+      - git fetch origin $BRANCH:$BRANCH --depth=1
       - git checkout $BRANCH
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -1,8 +1,6 @@
 version: 0.2
 
 env:
-  variables:
-    BRANCH: "mainline-2.x"
   secrets-manager:
     TWINE_USERNAME: PyPiAdmin:username 
     TWINE_PASSWORD: PyPiAdmin:password
@@ -16,7 +14,7 @@ phases:
       python: latest
   pre_build:
     commands:
-      - git fetch origin $BRANCH:$BRANCH --depth=1
+      - git fetch origin $COMMIT_ID:$COMMIT_ID --depth=1
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -17,7 +17,7 @@ phases:
   pre_build:
     commands:
       - git fetch origin $BRANCH:$BRANCH --depth=1
-      - git checkout $BRANCH
+      - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    BRANCH: "master"
+    BRANCH: "mainline-2.x"
   secrets-manager:
     TWINE_USERNAME: TestPyPiCryptoTools:username 
     TWINE_PASSWORD: TestPyPiCryptoTools:password
@@ -16,7 +16,7 @@ phases:
       python: latest
   pre_build:
     commands:
-      - git checkout $COMMIT_ID
+      - git checkout $BRANCH
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -16,6 +16,7 @@ phases:
       python: latest
   pre_build:
     commands:
+      - git fetch origin $BRANCH:$BRANCH --depth=1
       - git checkout $BRANCH
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -1,8 +1,6 @@
 version: 0.2
 
 env:
-  variables:
-    BRANCH: "mainline-2.x"
   secrets-manager:
     TWINE_USERNAME: TestPyPiCryptoTools:username 
     TWINE_PASSWORD: TestPyPiCryptoTools:password
@@ -16,7 +14,7 @@ phases:
       python: latest
   pre_build:
     commands:
-      - git fetch origin $BRANCH:$BRANCH --depth=1
+      - git fetch origin $COMMIT_ID:$COMMIT_ID --depth=1
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -17,7 +17,7 @@ phases:
   pre_build:
     commands:
       - git fetch origin $BRANCH:$BRANCH --depth=1
-      - git checkout $BRANCH
+      - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then


### PR DESCRIPTION
*Description of changes:*
When executing the codebuild, it drops you in the `master`branch if we want to release from separate branch we need to first checkout that branch. We do this in the Java ESDK and works great.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

