### PR TITLE
chore: Mark 1.x as End-of-Support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,20 @@
 Changelog
 *********
 
+1.10.1 -- 2022-08-30
+====================
+
+Deprecation Announcement
+------------------------
+The AWS Encryption SDK for Python Major Version 1 is End of Support.
+It will no longer receive security updates or bug fixes.
+Consider updating to the latest version of the AWS Encryption SDK for Python.
+
+Maintenance
+-----------
+* Emit Deprecation Warning on library initialization
+
+
 1.10.0 -- 2022-06-20
 ====================
 

--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -1,0 +1,37 @@
+Overview
+========
+This page describes the support policy for the AWS Encryption SDK. We regularly provide the AWS Encryption SDK with updates that may contain support for new or updated APIs, new features, enhancements, bug fixes, security patches, or documentation updates. Updates may also address changes with dependencies, language runtimes, and operating systems.
+
+We recommend users to stay up-to-date with Encryption SDK releases to keep up with the latest features, security updates, and underlying dependencies. Continued use of an unsupported SDK version is not recommended and is done at the user’s discretion
+
+
+Major Version Lifecycle
+========================
+The AWS Encryption SDK follows the same major version lifecycle as the AWS SDK. For details on this lifecycle, see  `AWS SDKs and Tools Maintenance Policy`_.
+
+Version Support Matrix
+======================
+This table describes the current support status of each major version of the AWS Encryption SDK for Python. It also shows the next status each major version will transition to, and the date at which that transition will happen.
+
+.. list-table::
+    :widths: 30 50 50 50
+    :header-rows: 1
+
+    * - Major version
+      - Current status
+      - Next status
+      - Next status date
+    * - 1.x
+      - End of Support
+      - 
+      - 
+    * - 2.x
+      - End of Support
+      - 
+      - 
+    * - 3.x
+      - General Availability 
+      -
+      -
+
+.. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle

--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -36,6 +36,13 @@ from aws_encryption_sdk.streaming_client import (  # noqa
     StreamEncryptor,
 )
 
+warnings.warn(
+    'This major version (1.x) of the AWS Encryption SDK for Python has reached End-of-Support.\n' +
+    'It will no longer receive security updates or bug fixes.\n' +
+    'Consider updating to the latest version of the AWS Encryption SDK.',
+    DeprecationWarning,
+)
+
 
 @attr.s(hash=True)
 class EncryptionSDKClientConfig(object):

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -27,7 +27,7 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 USER_AGENT_SUFFIX = "AwsEncryptionSdkPython/{}".format(__version__)
 
 


### PR DESCRIPTION
*Issue #, if available:* Mark 1.x as End-of-Support

*Description of changes:*
- ESDK-Python emits a Deprecation warning on creation detailing 1.x is in End-of-Support
- Added the support policy from master
- updated the support policy from master to mark 1.x & 2.x as End-of-Support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

