### PR TITLE
chore: Mark 2.x as End-of-Support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 *********
 
+2.5.1 -- 2022-08-30
+===================
+
+Deprecation Announcement
+------------------------
+The AWS Encryption SDK for Python Major Version 2 is End of Support.
+It will no longer receive security updates or bug fixes.
+Consider updating to the latest version of the AWS Encryption SDK for Python.
+
+Maintenance
+------------------------
+* Emit Deprecation Warning on library initialization
+
 2.5.0 -- 2022-06-20
 ===================
 

--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -22,16 +22,16 @@ This table describes the current support status of each major version of the AWS
       - Next status
       - Next status date
     * - 1.x
-      - Maintenance
       - End of Support
-      - 2022-06-30
-    * - 2.x
-      - General Availability 
-      - Maintenance
-      - 2021-07-01
-    * - 3.x
       - 
+      - 
+    * - 2.x
+      - End of Support
+      - 
+      - 
+    * - 3.x
       - General Availability 
-      - 2021-07-01
+      -
+      -
 
 .. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle

--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -36,6 +36,13 @@ from aws_encryption_sdk.streaming_client import (  # noqa
     StreamEncryptor,
 )
 
+warnings.warn(
+    "This major version (2.x) of the AWS Encryption SDK for Python has reached End-of-Support.\n"
+    + "It will no longer receive security updates or bug fixes.\n"
+    + "Consider updating to the latest version of the AWS Encryption SDK.",
+    DeprecationWarning,
+)
+
 
 @attr.s(hash=True)
 class EncryptionSDKClientConfig(object):

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -27,7 +27,7 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 USER_AGENT_SUFFIX = "AwsEncryptionSdkPython/{}".format(__version__)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -247,7 +247,7 @@ deps = {[testenv:isort]deps}
 commands = {[testenv:isort]commands} -c
 
 [testenv:autoformat]
-basepython = python3
+basepython = python3.7
 deps =
     {[testenv:blacken]deps}
     {[testenv:isort]deps}


### PR DESCRIPTION
*Issue #, if available:* Mark 1.x as End-of-Support

*Description of changes:*
- ESDK-Python emits a Deprecation warning on creation detailing 2.x is in End-of-Support
- Added the support policy from master
- updated the support policy from master to mark 1.x & 2.x as End-of-Support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

