### PR TITLE
chore(release): add api token to staging release process

### DIFF
--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -4,8 +4,8 @@ env:
   variables:
     BRANCH: "master"
   secrets-manager:
-    TWINE_USERNAME: TestPyPiCryptoTools:username 
-    TWINE_PASSWORD: TestPyPiCryptoTools:password
+    TWINE_USERNAME: TestPyPiAPIToken:username 
+    TWINE_PASSWORD: TestPyPiAPIToken:password
 
 phases:
   install:

--- a/decrypt_oracle/test/pylintrc
+++ b/decrypt_oracle/test/pylintrc
@@ -5,7 +5,8 @@ disable =
     missing-docstring,  # we don't write docstrings for tests
     bad-continuation,  # we let black handle this
     ungrouped-imports,  # we let isort handle this
-    consider-using-f-string # disable until 2022-05-05; 6 months after 3.5 deprecation
+    consider-using-f-string, # disable until 2022-05-05; 6 months after 3.5 deprecation
+    missing-timeout # disabling until we come up with a reasonable number
 
 [FORMAT]
 max-line-length = 120


### PR DESCRIPTION
*Description of changes:*
Uses API token instead of username and password to publish artifacts to TestPyPi. Token only has access to publish you cannot log into the account with it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

