### PR TITLE
chore(release): add api token to staging and prod release process

### DIFF
--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -2,8 +2,8 @@ version: 0.2
 
 env:
   secrets-manager:
-    TWINE_USERNAME: PyPiAdmin:username 
-    TWINE_PASSWORD: PyPiAdmin:password
+    TWINE_USERNAME: PyPiAPIToken:username 
+    TWINE_PASSWORD: PyPiAPIToken:password
 
 phases:
   install:

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -2,8 +2,8 @@ version: 0.2
 
 env:
   secrets-manager:
-    TWINE_USERNAME: TestPyPiCryptoTools:username 
-    TWINE_PASSWORD: TestPyPiCryptoTools:password
+    TWINE_USERNAME: TestPyPiAPIToken:username 
+    TWINE_PASSWORD: TestPyPiAPIToken:password
 
 phases:
   install:


### PR DESCRIPTION
*Description of changes:*
Use API Token for TestPyPi and PyPi instead of usesrname and password.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

