### PR TITLE
fix: update pyca range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3>=1.10.0
-cryptography>=2.5.0
+cryptography>=3.4.0
 attrs>=17.4.0
 wrapt>=1.10.11


### PR DESCRIPTION
*Issue #, if available:* [#307](https://github.com/aws/aws-encryption-sdk-cli/issues/307)

*Description of changes:*
- Update `cryptography` dependency range.

*Testing*:
I tested every Major Pyca since 2.5.0 explicitly via:
1. `sed -i.backup 's/cryptography>=2.5.0/cryptography==$PYCA/g' requirements.txt`
2. `tox -e py38-integ -r`
3. `git restore requirements.txt`
Where PYCA is one of `[2.*, 3.0.*, 3.1.*, 3.2.*, 3.3.*, 3.4.*, 3.4.0, 35.*, 36.*, 37.*]`.

The following failed: `[2.*, 3.0.*, 3.1.*, 3.2.*, 3.3.*]`
The rest succeeded.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

