### PR TITLE
chore: changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Consider updating to the latest version of the AWS Encryption SDK for Python.
 Maintenance
 ------------------------
 * Emit Deprecation Warning on library initialization
+* Update ``cryptography`` range to greater than or equal to 2.5.0 less than 37
 
 2.5.0 -- 2022-06-20
 ===================


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
Update CHANGELOG for 2.5.1 release.

Note:
While `cryptography==3.3.2` was the last to support Python2.7,
`pip` is clever enough to use `3.3.2` on Python2.7 and the latest available for other Pythons.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

