### PR TITLE
fix: Use FORBID_ENCRYPT_ALLOW_DECRYPT policy for decrypt oracle

### DIFF
--- a/codebuild/coverage/coverage.yml
+++ b/codebuild/coverage/coverage.yml
@@ -10,5 +10,5 @@ phases:
       python: latest
   build:
     commands:
-      - pip install tox
+      - pip install "tox < 4.0"
       - tox

--- a/codebuild/py310/awses_local.yml
+++ b/codebuild/py310/awses_local.yml
@@ -22,6 +22,6 @@ phases:
     commands:
       - pyenv install 3.10.0
       - pyenv local 3.10.0
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - cd test_vector_handlers
       - tox

--- a/codebuild/py310/examples.yml
+++ b/codebuild/py310/examples.yml
@@ -20,5 +20,5 @@ phases:
     commands:
       - pyenv install 3.10.0
       - pyenv local 3.10.0
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - tox

--- a/codebuild/py310/integ.yml
+++ b/codebuild/py310/integ.yml
@@ -20,5 +20,5 @@ phases:
     commands:
       - pyenv install 3.10.0
       - pyenv local 3.10.0
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - tox

--- a/codebuild/py37/awses_local.yml
+++ b/codebuild/py37/awses_local.yml
@@ -22,6 +22,6 @@ phases:
     commands:
       - pyenv install 3.7.12
       - pyenv local 3.7.12
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - cd test_vector_handlers
       - tox

--- a/codebuild/py37/examples.yml
+++ b/codebuild/py37/examples.yml
@@ -20,5 +20,5 @@ phases:
     commands:
       - pyenv install 3.7.12
       - pyenv local 3.7.12
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - tox

--- a/codebuild/py37/integ.yml
+++ b/codebuild/py37/integ.yml
@@ -20,5 +20,5 @@ phases:
     commands:
       - pyenv install 3.7.12
       - pyenv local 3.7.12
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - tox

--- a/codebuild/py38/awses_local.yml
+++ b/codebuild/py38/awses_local.yml
@@ -22,6 +22,6 @@ phases:
     commands:
       - pyenv install 3.8.12
       - pyenv local 3.8.12
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - cd test_vector_handlers
       - tox

--- a/codebuild/py38/examples.yml
+++ b/codebuild/py38/examples.yml
@@ -20,5 +20,5 @@ phases:
     commands:
       - pyenv install 3.8.12
       - pyenv local 3.8.12
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - tox

--- a/codebuild/py38/integ.yml
+++ b/codebuild/py38/integ.yml
@@ -20,5 +20,5 @@ phases:
     commands:
       - pyenv install 3.8.12
       - pyenv local 3.8.12
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - tox

--- a/codebuild/py39/awses_1.7.1.yml
+++ b/codebuild/py39/awses_1.7.1.yml
@@ -22,6 +22,6 @@ phases:
     commands:
       - pyenv install 3.9.7
       - pyenv local 3.9.7
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - cd test_vector_handlers
       - tox

--- a/codebuild/py39/awses_2.0.0.yml
+++ b/codebuild/py39/awses_2.0.0.yml
@@ -22,6 +22,6 @@ phases:
     commands:
       - pyenv install 3.9.7
       - pyenv local 3.9.7
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - cd test_vector_handlers
       - tox

--- a/codebuild/py39/awses_latest.yml
+++ b/codebuild/py39/awses_latest.yml
@@ -22,6 +22,6 @@ phases:
     commands:
       - pyenv install 3.9.7
       - pyenv local 3.9.7
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - cd test_vector_handlers
       - tox

--- a/codebuild/py39/examples.yml
+++ b/codebuild/py39/examples.yml
@@ -20,5 +20,5 @@ phases:
     commands:
       - pyenv install 3.9.7
       - pyenv local 3.9.7
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - tox

--- a/codebuild/py39/integ.yml
+++ b/codebuild/py39/integ.yml
@@ -20,5 +20,5 @@ phases:
     commands:
       - pyenv install 3.9.7
       - pyenv local 3.9.7
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
       - tox

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -10,7 +10,7 @@ env:
 phases:
   install:
     commands:
-      - pip install tox
+      - pip install "tox < 4.0"
       - pip install --upgrade pip
     runtime-versions:
       python: latest

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -10,7 +10,7 @@ env:
 phases:
   install:
     commands:
-      - pip install tox
+      - pip install "tox < 4.0"
       - pip install --upgrade pip
     runtime-versions:
       python: latest

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     commands:
-      - pip install tox
+      - pip install "tox < 4.0"
     runtime-versions:
       python: latest
   pre_build:
@@ -13,7 +13,7 @@ phases:
       - sed -i "s/aws_encryption_sdk/aws_encryption_sdk==$VERSION/" requirements-dev.txt
       - pyenv install 3.8.12
       - pyenv local 3.8.12
-      - pip install tox tox-pyenv
+      - pip install "tox < 4.0"
   build:
     commands:
       - NUM_RETRIES=3

--- a/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/app.py
+++ b/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/app.py
@@ -60,7 +60,7 @@ def basic_decrypt() -> Response:
     APP.log.debug(APP.current_request.raw_body)
 
     try:
-        # The decrypt oracle needs to be able to decrypt any message 
+        # The decrypt oracle needs to be able to decrypt any message
         # it does not encrypt messages for anyone.
         client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
         ciphertext = APP.current_request.raw_body

--- a/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/app.py
+++ b/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/app.py
@@ -60,8 +60,8 @@ def basic_decrypt() -> Response:
     APP.log.debug(APP.current_request.raw_body)
 
     try:
-        // The decrypt oracle needs to be able to decrypt any message
-        // it does not encrypt messages for anyone.
+        # The decrypt oracle needs to be able to decrypt any message 
+        # it does not encrypt messages for anyone.
         client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
         ciphertext = APP.current_request.raw_body
         plaintext, _header = client.decrypt(source=ciphertext, key_provider=_master_key_provider())

--- a/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/app.py
+++ b/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/app.py
@@ -16,6 +16,7 @@ import logging
 import os
 
 import aws_encryption_sdk
+from aws_encryption_sdk.identifiers import CommitmentPolicy
 from aws_encryption_sdk.key_providers.kms import DiscoveryAwsKmsMasterKeyProvider
 from chalice import Chalice, Response
 
@@ -59,7 +60,7 @@ def basic_decrypt() -> Response:
     APP.log.debug(APP.current_request.raw_body)
 
     try:
-        client = aws_encryption_sdk.EncryptionSDKClient()
+        client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
         ciphertext = APP.current_request.raw_body
         plaintext, _header = client.decrypt(source=ciphertext, key_provider=_master_key_provider())
         APP.log.debug("Plaintext:")

--- a/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/app.py
+++ b/decrypt_oracle/src/aws_encryption_sdk_decrypt_oracle/app.py
@@ -60,6 +60,8 @@ def basic_decrypt() -> Response:
     APP.log.debug(APP.current_request.raw_body)
 
     try:
+        // The decrypt oracle needs to be able to decrypt any message
+        // it does not encrypt messages for anyone.
         client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
         ciphertext = APP.current_request.raw_body
         plaintext, _header = client.decrypt(source=ciphertext, key_provider=_master_key_provider())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

fix: Updates the decrypt oracle commitment policy to `FORBID_ENCRYPT_ALLOW_DECRYPT` to be backwards compatible.

*Testing*
Deployed and tested on dev account

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

