### PR TITLE
fix: wrong formatting python warning (#545)

### DIFF
--- a/src/aws_encryption_sdk/compatability.py
+++ b/src/aws_encryption_sdk/compatability.py
@@ -35,5 +35,5 @@ def _warn_deprecated_python():
             "bug fixes, and security updates please upgrade to Python {}.{} or "
             "later. For more information, see SUPPORT_POLICY.rst: "
             "https://github.com/aws/aws-encryption-sdk-python/blob/master/SUPPORT_POLICY.rst"
-        ).format(py_version[0], py_version[1], minimum_version[0], minimum_version[1], params["date"])
+        ).format(py_version[0], py_version[1], params["date"], minimum_version[0], minimum_version[1])
         warnings.warn(warning, DeprecationWarning)


### PR DESCRIPTION
*Issue #545 :*

*Description of changes:*
Swapped `minimum_version` and `date` as described in issue solution


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

