### PR TITLE
chore: freeze py311 depedencies for pyca and test in CI

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -31,7 +31,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-          - 3.10
+          - "3.10"
           - "3.11"
           - 3.x  # Ideally, we would skip if 3.x is 3.11
         architecture:

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -31,7 +31,9 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-          - 3.x
+          - 3.10
+          - 3.11
+          - 3.x  # Ideally, we would skip if 3.x is 3.11
         architecture:
           - x64
           - x86
@@ -61,7 +63,7 @@ jobs:
         env:
           TOXENV: ${{ matrix.category }}
         run: tox -- -vv
-  upstream-py3:
+  upstream-py37:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -74,6 +76,26 @@ jobs:
         - uses: actions/setup-python@v4
           with:
             python-version: 3.7
+        - run: |
+            python -m pip install --upgrade pip
+            pip install --upgrade -r dev_requirements/ci-requirements.txt
+        - name: run test
+          env:
+            TOXENV: ${{ matrix.category }}
+          run: tox -- -vv
+  upstream-py311:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        category:
+          - nocmk
+          - test-upstream-requirements-py311
+    steps:
+        - uses: actions/checkout@v3
+        - uses: actions/setup-python@v4
+          with:
+            python-version: 3.11
         - run: |
             python -m pip install --upgrade pip
             pip install --upgrade -r dev_requirements/ci-requirements.txt

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -32,7 +32,7 @@ jobs:
           - 3.8
           - 3.9
           - 3.10
-          - 3.11
+          - "3.11"
           - 3.x  # Ideally, we would skip if 3.x is 3.11
         architecture:
           - x64
@@ -95,7 +95,7 @@ jobs:
         - uses: actions/checkout@v3
         - uses: actions/setup-python@v4
           with:
-            python-version: 3.11
+            python-version: "3.11"
         - run: |
             python -m pip install --upgrade pip
             pip install --upgrade -r dev_requirements/ci-requirements.txt

--- a/test/upstream-requirements-py311.txt
+++ b/test/upstream-requirements-py311.txt
@@ -4,8 +4,6 @@ botocore==1.29.54
 cffi==1.15.1
 coverage==7.0.5
 cryptography==39.0.0
-exceptiongroup==1.1.0
-importlib-metadata==6.0.0
 iniconfig==2.0.0
 jmespath==1.0.1
 mock==4.0.3
@@ -18,8 +16,5 @@ pytest-mock==3.6.1
 python-dateutil==2.8.2
 s3transfer==0.6.0
 six==1.16.0
-tomli==2.0.1
-typing_extensions==4.4.0
 urllib3==1.26.14
 wrapt==1.14.1
-zipp==3.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-{local,integ,accept,examples}, nocmk,
+    py{37,38,39,310,311}-{local,integ,accept,examples}, nocmk,
     bandit, doc8, readme, docs,
     {flake8,pylint}{,-tests,-examples},
     isort-check, black-check,
@@ -103,6 +103,15 @@ recreate = {[testenv:freeze-upstream-requirements-base]recreate}
 deps = {[testenv:freeze-upstream-requirements-base]deps}
 commands = {[testenv:freeze-upstream-requirements-base]commands} test/upstream-requirements-py37.txt
 
+# Freeze for Python 3.11
+[testenv:freeze-upstream-requirements-py311]
+basepython = python3.11
+sitepackages = {[testenv:freeze-upstream-requirements-base]sitepackages}
+skip_install = {[testenv:freeze-upstream-requirements-base]skip_install}
+recreate = {[testenv:freeze-upstream-requirements-base]recreate}
+deps = {[testenv:freeze-upstream-requirements-base]deps}
+commands = {[testenv:freeze-upstream-requirements-base]commands} test/upstream-requirements-py311.txt
+
 # Test frozen upstream requirements
 [testenv:test-upstream-requirements-base]
 sitepackages = False
@@ -113,6 +122,14 @@ commands = {[testenv:base-command]commands} test/ -m local
 [testenv:test-upstream-requirements-py37]
 basepython = python3.7
 deps = -rtest/upstream-requirements-py37.txt
+sitepackages = {[testenv:test-upstream-requirements-base]sitepackages}
+recreate = {[testenv:test-upstream-requirements-base]recreate}
+commands = {[testenv:test-upstream-requirements-base]commands}
+
+# Test frozen upstream requirements for Python 3.11
+[testenv:test-upstream-requirements-py311]
+basepython = python3.11
+deps = -rtest/upstream-requirements-py311.txt
 sitepackages = {[testenv:test-upstream-requirements-base]sitepackages}
 recreate = {[testenv:test-upstream-requirements-base]recreate}
 commands = {[testenv:test-upstream-requirements-base]commands}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/pyca/cryptography/pull/8115

*Description of changes:* 
- Explicitly test Python 3.10 & Python 3.11 in CI.
- Update Freeze Dependencies for Python 3.7
- Add Freeze Dependencies for Python 3.11


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

