### PR TITLE
chore: skip pyenv installation if already exists

### DIFF
--- a/codebuild/py312/awses_local.yml
+++ b/codebuild/py312/awses_local.yml
@@ -21,7 +21,7 @@ phases:
   build:
     commands:
       - cd /root/.pyenv/plugins/python-build/../.. && git pull && cd -
-      - pyenv install 3.12.0
+      - pyenv install --skip-existing 3.12.0
       - pyenv local 3.12.0
       - pip install --upgrade pip
       - pip install setuptools

--- a/codebuild/py312/examples.yml
+++ b/codebuild/py312/examples.yml
@@ -19,7 +19,7 @@ phases:
   build:
     commands:
       - cd /root/.pyenv/plugins/python-build/../.. && git pull && cd -
-      - pyenv install 3.12.0
+      - pyenv install --skip-existing 3.12.0
       - pyenv local 3.12.0
       - pip install --upgrade pip
       - pip install setuptools

--- a/codebuild/py312/integ.yml
+++ b/codebuild/py312/integ.yml
@@ -19,7 +19,7 @@ phases:
   build:
     commands:
       - cd /root/.pyenv/plugins/python-build/../.. && git pull && cd -
-      - pyenv install 3.12.0
+      - pyenv install --skip-existing 3.12.0
       - pyenv local 3.12.0
       - pip install --upgrade pip
       - pip install setuptools

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -11,7 +11,7 @@ phases:
       - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
       - cd busy-engineers-document-bucket/exercises/python/encryption-context-complete
       - sed -i "s/aws_encryption_sdk/aws_encryption_sdk==$VERSION/" requirements-dev.txt
-      - pyenv install 3.8.12
+      - pyenv install --skip-existing 3.8.12
       - pyenv local 3.8.12
       - pip install "tox < 4.0"
   build:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- codebuild ci is failing with `pyenv 3.12.0 already exists`, with this change ci will skip `pyenv` installation if already exists

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

