### PR TITLE
fix(.readthedocs.yaml): fix docs failing issue

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the doc/ directory with Sphinx
 sphinx:
    configuration: doc/conf.py
@@ -15,8 +21,7 @@ submodules:
   exclude: all
 
 python:
-  version: 3.8
   install:
     - requirements: dev_requirements/doc-requirements.txt
-    - method: setuptools
+    - method: pip
       path: .


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix for docs failing issue for ESDK-python

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

