### PR TITLE
chore: add PyPi API tokens to Cfn template

### DIFF
--- a/cfn/ESDK-Python.yml
+++ b/cfn/ESDK-Python.yml
@@ -312,7 +312,9 @@ Resources:
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:secretsmanager:us-west-2:587316601012:secret:TestPyPiCryptoTools-SxeLBh",
-                "arn:aws:secretsmanager:us-west-2:587316601012:secret:PyPiAdmin-ZWyd1T"
+                "arn:aws:secretsmanager:us-west-2:587316601012:secret:TestPyPiAPIToken-uERFjs",
+                "arn:aws:secretsmanager:us-west-2:587316601012:secret:PyPiAdmin-ZWyd1T",
+                "arn:aws:secretsmanager:us-west-2:587316601012:secret:PyPiAPIToken-nu1Gu6"
               ],
               "Action": "secretsmanager:GetSecretValue"
             }


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* updates the CFN template to include the "new" PyPi secrets which move us to API token. this was manually changed in the account for the previous release, but not reflected in CFN. there are some other changes which I am not attempting to fix until we run a release, so as to avoid breaking our release. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

