### PR TITLE
fix(CI): Fix oracle linting

### DIFF
--- a/decrypt_oracle/.chalice/pipeline.py
+++ b/decrypt_oracle/.chalice/pipeline.py
@@ -145,7 +145,6 @@ def _cloudformation_role() -> iam.Role:
     )
 
 
-# pylint: disable=too-many-positional-arguments
 def _pipeline(
     pipeline_role: iam.Role,
     cfn_role: iam.Role,

--- a/decrypt_oracle/.chalice/pipeline.py
+++ b/decrypt_oracle/.chalice/pipeline.py
@@ -145,6 +145,7 @@ def _cloudformation_role() -> iam.Role:
     )
 
 
+# pylint: disable=too-many-positional-arguments
 def _pipeline(
     pipeline_role: iam.Role,
     cfn_role: iam.Role,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Somehow, the oracle linter stopped working.
See CI for a commit that makes no changes to the repo: [link](https://github.com/aws/aws-encryption-sdk-python/actions/runs/11150896553/job/30993110138)
Let's ignore this linter failure -- we haven't touched this in years and almost certainly will put significant dev work into this again, so I'd rather not refactor this.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

