### PR TITLE
chore(examples): fix comments

### DIFF
--- a/examples/src/aws_kms_discovery_keyring_example.py
+++ b/examples/src/aws_kms_discovery_keyring_example.py
@@ -164,7 +164,7 @@ def encrypt_and_decrypt_with_keyring(
     assert plaintext_bytes == EXAMPLE_DATA, \
         "Decrypted plaintext should be identical to the original plaintext. Invalid decryption"
 
-    # 11. Demonstrate that if a discovery keyring (Bob's) doesn't have the correct AWS Account ID's,
+    # 10. Demonstrate that if a discovery keyring (Bob's) doesn't have the correct AWS Account ID's,
     # the decrypt will fail with an error message
     # Note that this assumes Account ID used here ('888888888888') is different than the one used
     # during encryption

--- a/examples/src/aws_kms_discovery_keyring_example.py
+++ b/examples/src/aws_kms_discovery_keyring_example.py
@@ -164,8 +164,8 @@ def encrypt_and_decrypt_with_keyring(
     assert plaintext_bytes == EXAMPLE_DATA, \
         "Decrypted plaintext should be identical to the original plaintext. Invalid decryption"
 
-    # 10. Demonstrate that if a discovery keyring (Bob's) doesn't have the correct AWS Account ID's,
-    # the decrypt will fail with an error message
+    # 10. Demonstrate that if a different discovery keyring (Bob's) doesn't have the correct
+    # AWS Account ID's, the decrypt will fail with an error message
     # Note that this assumes Account ID used here ('888888888888') is different than the one used
     # during encryption
     discovery_keyring_input_bob: CreateAwsKmsDiscoveryKeyringInput = \

--- a/examples/src/aws_kms_discovery_keyring_example.py
+++ b/examples/src/aws_kms_discovery_keyring_example.py
@@ -23,9 +23,8 @@ This example creates a KMS Keyring and then encrypts a custom input EXAMPLE_DATA
 with an encryption context. This encrypted ciphertext is then decrypted using the Discovery keyring.
 This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
-4. Decryption is only possible if the Discovery Keyring contains the correct AWS Account ID's to
+2. Decrypted plaintext value matches EXAMPLE_DATA
+3. Decryption is only possible if the Discovery Keyring contains the correct AWS Account ID's to
     which the KMS key used for encryption belongs
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 

--- a/examples/src/aws_kms_discovery_multi_keyring_example.py
+++ b/examples/src/aws_kms_discovery_multi_keyring_example.py
@@ -22,8 +22,7 @@ This example creates a KMS Keyring and then encrypts a custom input EXAMPLE_DATA
 with an encryption context. This encrypted ciphertext is then decrypted using the Discovery Multi
 keyring. This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 For more information on how to use KMS Discovery keyrings, see

--- a/examples/src/aws_kms_keyring_example.py
+++ b/examples/src/aws_kms_keyring_example.py
@@ -7,8 +7,7 @@ The AWS KMS keyring uses symmetric encryption KMS keys to generate, encrypt and
 decrypt data keys. This example creates a KMS Keyring and then encrypts a custom input EXAMPLE_DATA
 with an encryption context. This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 AWS KMS keyrings can be used independently or in a multi-keyring with other keyrings

--- a/examples/src/aws_kms_mrk_discovery_keyring_example.py
+++ b/examples/src/aws_kms_mrk_discovery_keyring_example.py
@@ -21,8 +21,7 @@ This example creates a KMS MRK Keyring and then encrypts a custom input EXAMPLE_
 with an encryption context. This encrypted ciphertext is then decrypted using an
 MRK Discovery keyring. This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 For information about using multi-Region keys with the AWS Encryption SDK, see

--- a/examples/src/aws_kms_mrk_discovery_multi_keyring_example.py
+++ b/examples/src/aws_kms_mrk_discovery_multi_keyring_example.py
@@ -23,8 +23,7 @@ This example creates a KMS MRK Keyring and then encrypts a custom input EXAMPLE_
 with an encryption context. This encrypted ciphertext is then decrypted using an
 MRK Discovery Multi keyring. This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 For information about using multi-Region keys with the AWS Encryption SDK, see

--- a/examples/src/aws_kms_mrk_keyring_example.py
+++ b/examples/src/aws_kms_mrk_keyring_example.py
@@ -8,8 +8,7 @@ create, encrypt, and decrypt data keys with multi-region AWS KMS keys (MRKs).
 This example creates a KMS MRK Keyring and then encrypts a custom input EXAMPLE_DATA
 with an encryption context. This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 AWS KMS MRK keyrings can be used independently or in a multi-keyring with other keyrings

--- a/examples/src/aws_kms_mrk_multi_keyring_example.py
+++ b/examples/src/aws_kms_mrk_multi_keyring_example.py
@@ -14,9 +14,8 @@ as a child key, and then encrypts a custom input EXAMPLE_DATA with an encryption
 Either KMS Key individually is capable of decrypting data encrypted under this keyring.
 This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
-4. Ciphertext can be decrypted using an AwsKmsMrkKeyring containing a replica of the
+2. Decrypted plaintext value matches EXAMPLE_DATA
+3. Ciphertext can be decrypted using an AwsKmsMrkKeyring containing a replica of the
    MRK (from the multi-keyring used for encryption) copied from the first region into
    the second region
 These sanity checks are for demonstration in the example only. You do not need these in your code.

--- a/examples/src/aws_kms_rsa_keyring_example.py
+++ b/examples/src/aws_kms_rsa_keyring_example.py
@@ -7,8 +7,7 @@ This example creates a KMS RSA Keyring and then encrypts a custom input
 EXAMPLE_DATA with an encryption context. This example also includes some sanity checks for
 demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 # For more information on how to use KMS keyrings, see

--- a/examples/src/default_cryptographic_materials_manager_example.py
+++ b/examples/src/default_cryptographic_materials_manager_example.py
@@ -11,8 +11,7 @@ with an encryption context. Creating a CMM involves taking a keyring as input,
 and we use an AWS KMS Keyring for this example.
 This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 For more information on Cryptographic Material Managers, see

--- a/examples/src/file_streaming_example.py
+++ b/examples/src/file_streaming_example.py
@@ -13,8 +13,7 @@ This example creates a Raw AES Keyring and then encrypts an input stream from th
 It then decrypts the ciphertext from `ciphertext_filename` to a new file `decrypted_filename`.
 This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 For more information on how to use Raw AES keyrings, see

--- a/examples/src/migration/migration_set_commitment_policy_example.py
+++ b/examples/src/migration/migration_set_commitment_policy_example.py
@@ -13,8 +13,7 @@ This example creates a KMS Keyring and then encrypts a custom input EXAMPLE_DATA
 with an encryption context for the commitment policy FORBID_ENCRYPT_ALLOW_DECRYPT.
 This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 For more information on setting your commitment policy, see

--- a/examples/src/raw_aes_keyring_example.py
+++ b/examples/src/raw_aes_keyring_example.py
@@ -11,8 +11,7 @@ when you need to provide the wrapping key and encrypt the data keys locally or o
 This example creates a Raw AES Keyring and then encrypts a custom input EXAMPLE_DATA
 with an encryption context. This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 The Raw AES keyring encrypts data by using the AES-GCM algorithm and a wrapping key that

--- a/examples/src/raw_rsa_keyring_example.py
+++ b/examples/src/raw_rsa_keyring_example.py
@@ -15,9 +15,8 @@ decrypts the data key using the private key.
 This example creates a Raw RSA Keyring and then encrypts a custom input EXAMPLE_DATA
 with an encryption context. This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
-4. The original ciphertext is not decryptable using a keyring with a different RSA key pair
+2. Decrypted plaintext value matches EXAMPLE_DATA
+3. The original ciphertext is not decryptable using a keyring with a different RSA key pair
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 A Raw RSA keyring that encrypts and decrypts must include an asymmetric public key and private

--- a/examples/src/set_encryption_algorithm_suite_example.py
+++ b/examples/src/set_encryption_algorithm_suite_example.py
@@ -31,8 +31,7 @@ This example creates a Raw AES Keyring and then encrypts a custom input EXAMPLE_
 with an encryption context and the algorithm suite AES_256_GCM_HKDF_SHA512_COMMIT_KEY.
 This example also includes some sanity checks for demonstration:
 1. Ciphertext and plaintext data are not the same
-2. Encryption context is correct in the decrypted message header
-3. Decrypted plaintext value matches EXAMPLE_DATA
+2. Decrypted plaintext value matches EXAMPLE_DATA
 These sanity checks are for demonstration in the example only. You do not need these in your code.
 
 For more information on how to use Raw AES keyrings, see


### PR DESCRIPTION
*Issue #, if available:*
 
*Description of changes:*
We removed code that explicitly checked "Encryption context is correct in the decrypted message header", and now recommend providing encryption context directly on decrypt. Removing this statement from all examples.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

