### PR TITLE
chore(MPL): Rename MPL Python package

### DIFF
--- a/examples/src/aws_kms_discovery_keyring_example.py
+++ b/examples/src/aws_kms_discovery_keyring_example.py
@@ -33,14 +33,14 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-kms-keyrin
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CreateAwsKmsDiscoveryKeyringInput,
     CreateAwsKmsKeyringInput,
     DiscoveryFilter,
 )
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/aws_kms_discovery_multi_keyring_example.py
+++ b/examples/src/aws_kms_discovery_multi_keyring_example.py
@@ -30,14 +30,14 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-kms-keyrin
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CreateAwsKmsDiscoveryMultiKeyringInput,
     CreateAwsKmsKeyringInput,
     DiscoveryFilter,
 )
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/aws_kms_keyring_example.py
+++ b/examples/src/aws_kms_keyring_example.py
@@ -18,10 +18,10 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-kms-keyrin
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/aws_kms_mrk_discovery_keyring_example.py
+++ b/examples/src/aws_kms_mrk_discovery_keyring_example.py
@@ -35,14 +35,14 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-kms-keyrin
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CreateAwsKmsMrkDiscoveryKeyringInput,
     CreateAwsKmsMrkKeyringInput,
     DiscoveryFilter,
 )
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/aws_kms_mrk_discovery_multi_keyring_example.py
+++ b/examples/src/aws_kms_mrk_discovery_multi_keyring_example.py
@@ -37,14 +37,14 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-kms-keyrin
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CreateAwsKmsMrkDiscoveryMultiKeyringInput,
     CreateAwsKmsMrkKeyringInput,
     DiscoveryFilter,
 )
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/aws_kms_mrk_keyring_example.py
+++ b/examples/src/aws_kms_mrk_keyring_example.py
@@ -22,10 +22,10 @@ https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsMrkKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsMrkKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/aws_kms_mrk_multi_keyring_example.py
+++ b/examples/src/aws_kms_mrk_multi_keyring_example.py
@@ -30,7 +30,10 @@ https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview
 import boto3
 from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
 from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsMrkKeyringInput, CreateAwsKmsMrkMultiKeyringInput
+from aws_cryptographic_material_providers.mpl.models import (
+    CreateAwsKmsMrkKeyringInput,
+    CreateAwsKmsMrkMultiKeyringInput
+)
 from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 

--- a/examples/src/aws_kms_mrk_multi_keyring_example.py
+++ b/examples/src/aws_kms_mrk_multi_keyring_example.py
@@ -28,10 +28,10 @@ https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsMrkKeyringInput, CreateAwsKmsMrkMultiKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsMrkKeyringInput, CreateAwsKmsMrkMultiKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/aws_kms_mrk_multi_keyring_example.py
+++ b/examples/src/aws_kms_mrk_multi_keyring_example.py
@@ -32,7 +32,7 @@ from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialPro
 from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
 from aws_cryptographic_material_providers.mpl.models import (
     CreateAwsKmsMrkKeyringInput,
-    CreateAwsKmsMrkMultiKeyringInput
+    CreateAwsKmsMrkMultiKeyringInput,
 )
 from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order

--- a/examples/src/aws_kms_multi_keyring_example.py
+++ b/examples/src/aws_kms_multi_keyring_example.py
@@ -38,10 +38,10 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-multi-keyr
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsKeyringInput, CreateAwsKmsMultiKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsKeyringInput, CreateAwsKmsMultiKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/aws_kms_rsa_keyring_example.py
+++ b/examples/src/aws_kms_rsa_keyring_example.py
@@ -15,10 +15,10 @@ These sanity checks are for demonstration in the example only. You do not need t
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsRsaKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsRsaKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/branch_key_id_supplier_example.py
+++ b/examples/src/branch_key_id_supplier_example.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Example implementation of a branch key ID supplier."""
 
-from aws_cryptographic_materialproviders.mpl.models import GetBranchKeyIdInput, GetBranchKeyIdOutput
-from aws_cryptographic_materialproviders.mpl.references import IBranchKeyIdSupplier
+from aws_cryptographic_material_providers.mpl.models import GetBranchKeyIdInput, GetBranchKeyIdOutput
+from aws_cryptographic_material_providers.mpl.references import IBranchKeyIdSupplier
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 

--- a/examples/src/custom_mpl_cmm_example.py
+++ b/examples/src/custom_mpl_cmm_example.py
@@ -23,13 +23,13 @@ For more information on Cryptographic Material Managers, see
 https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html#crypt-materials-manager
 """
 
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CreateDefaultCryptographicMaterialsManagerInput,
     SignatureAlgorithmNone,
 )
-from aws_cryptographic_materialproviders.mpl.references import ICryptographicMaterialsManager, IKeyring
+from aws_cryptographic_material_providers.mpl.references import ICryptographicMaterialsManager, IKeyring
 
 import aws_encryption_sdk
 from aws_encryption_sdk import CommitmentPolicy
@@ -65,10 +65,10 @@ class MPLCustomSigningSuiteOnlyCMM(ICryptographicMaterialsManager):
     def get_encryption_materials(self, param):
         """Provides encryption materials appropriate for the request for the custom CMM.
 
-        :param aws_cryptographic_materialproviders.mpl.models.GetEncryptionMaterialsInput param: Input object to
+        :param aws_cryptographic_material_providers.mpl.models.GetEncryptionMaterialsInput param: Input object to
         provide to a crypto material manager's `get_encryption_materials` method.
         :returns: Encryption materials output
-        :rtype: aws_cryptographic_materialproviders.mpl.models.GetEncryptionMaterialsOutput
+        :rtype: aws_cryptographic_material_providers.mpl.models.GetEncryptionMaterialsOutput
         """
         materials = self.underlying_cmm.get_encryption_materials(param)
         if isinstance(materials.encryption_materials.algorithm_suite.signature, SignatureAlgorithmNone):
@@ -81,10 +81,10 @@ class MPLCustomSigningSuiteOnlyCMM(ICryptographicMaterialsManager):
     def decrypt_materials(self, param):
         """Provides decryption materials appropriate for the request for the custom CMM.
 
-        :param aws_cryptographic_materialproviders.mpl.models.DecryptMaterialsInput param: Input object to provide
+        :param aws_cryptographic_material_providers.mpl.models.DecryptMaterialsInput param: Input object to provide
         to a crypto material manager's `decrypt_materials` method.
         :returns: Decryption materials output
-        :rtype: aws_cryptographic_materialproviders.mpl.models.GetDecryptionMaterialsOutput
+        :rtype: aws_cryptographic_material_providers.mpl.models.GetDecryptionMaterialsOutput
         """
         materials = self.underlying_cmm.decrypt_materials(param)
         if isinstance(materials.decryption_materials.algorithm_suite.signature, SignatureAlgorithmNone):

--- a/examples/src/default_cryptographic_materials_manager_example.py
+++ b/examples/src/default_cryptographic_materials_manager_example.py
@@ -18,13 +18,13 @@ For more information on Cryptographic Material Managers, see
 https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html#crypt-materials-manager
 """
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CreateAwsKmsKeyringInput,
     CreateDefaultCryptographicMaterialsManagerInput,
 )
-from aws_cryptographic_materialproviders.mpl.references import ICryptographicMaterialsManager, IKeyring
+from aws_cryptographic_material_providers.mpl.references import ICryptographicMaterialsManager, IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/file_streaming_example.py
+++ b/examples/src/file_streaming_example.py
@@ -25,10 +25,10 @@ in the AWS Encryption SDK for Python.
 import filecmp
 import secrets
 
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/hierarchical_keyring_example.py
+++ b/examples/src/hierarchical_keyring_example.py
@@ -35,17 +35,17 @@ GenerateDataKeyWithoutPlaintext - Decrypt
 import boto3
 # Ignore missing MPL for pylint, but the MPL is required for this example
 # noqa pylint: disable=import-error
-from aws_cryptographic_materialproviders.keystore import KeyStore
-from aws_cryptographic_materialproviders.keystore.config import KeyStoreConfig
-from aws_cryptographic_materialproviders.keystore.models import CreateKeyInput, KMSConfigurationKmsKeyArn
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.keystore import KeyStore
+from aws_cryptographic_material_providers.keystore.config import KeyStoreConfig
+from aws_cryptographic_material_providers.keystore.models import CreateKeyInput, KMSConfigurationKmsKeyArn
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CacheTypeDefault,
     CreateAwsKmsHierarchicalKeyringInput,
     DefaultCache,
 )
-from aws_cryptographic_materialproviders.mpl.references import IBranchKeyIdSupplier, IKeyring
+from aws_cryptographic_material_providers.mpl.references import IBranchKeyIdSupplier, IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/migration/migration_aws_kms_key_example.py
+++ b/examples/src/migration/migration_aws_kms_key_example.py
@@ -21,10 +21,10 @@ For more information on how to use KMS keyrings, see
 https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-kms-keyring.html
 """
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/migration/migration_raw_aes_key_example.py
+++ b/examples/src/migration/migration_raw_aes_key_example.py
@@ -26,10 +26,10 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-raw-aes-ke
 """
 import secrets
 
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/migration/migration_raw_rsa_key_example.py
+++ b/examples/src/migration/migration_raw_rsa_key_example.py
@@ -28,10 +28,10 @@ But both ciphertexts when decrypted using keyring and MKP will give the same pla
 For more information on how to use Raw RSA keyrings, see
 https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-raw-rsa-keyring.html
 """
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateRawRsaKeyringInput, PaddingScheme
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateRawRsaKeyringInput, PaddingScheme
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/examples/src/migration/migration_set_commitment_policy_example.py
+++ b/examples/src/migration/migration_set_commitment_policy_example.py
@@ -21,10 +21,10 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html#
 """
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/multi_keyring_example.py
+++ b/examples/src/multi_keyring_example.py
@@ -39,15 +39,15 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-multi-keyr
 import secrets
 
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     AesWrappingAlg,
     CreateAwsKmsKeyringInput,
     CreateMultiKeyringInput,
     CreateRawAesKeyringInput,
 )
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/multithreading/__init__.py
+++ b/examples/src/multithreading/__init__.py
@@ -3,7 +3,7 @@
 """init file for multi-threading examples."""
 import time
 
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/multithreading/raw_aes_keyring.py
+++ b/examples/src/multithreading/raw_aes_keyring.py
@@ -4,10 +4,10 @@
 
 import secrets
 
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 
 
 def create_keyring():

--- a/examples/src/multithreading/raw_rsa_keyring.py
+++ b/examples/src/multithreading/raw_rsa_keyring.py
@@ -1,10 +1,10 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """This file contains methods to use for testing multi-threading for Raw RSA keyring."""
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateRawRsaKeyringInput, PaddingScheme
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateRawRsaKeyringInput, PaddingScheme
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/examples/src/raw_aes_keyring_example.py
+++ b/examples/src/raw_aes_keyring_example.py
@@ -23,10 +23,10 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-raw-aes-ke
 """
 import secrets
 
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/raw_rsa_keyring_example.py
+++ b/examples/src/raw_rsa_keyring_example.py
@@ -33,10 +33,10 @@ For more information on how to use Raw RSA keyrings, see
 https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-raw-rsa-keyring.html
 """
 
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateRawRsaKeyringInput, PaddingScheme
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateRawRsaKeyringInput, PaddingScheme
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/examples/src/required_encryption_context_cmm.py
+++ b/examples/src/required_encryption_context_cmm.py
@@ -10,14 +10,14 @@ On decrypt, the client MUST supply the key/value pair(s) that were not stored to
 import boto3
 # Ignore missing MPL for pylint, but the MPL is required for this example
 # noqa pylint: disable=import-error
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CreateAwsKmsKeyringInput,
     CreateDefaultCryptographicMaterialsManagerInput,
     CreateRequiredEncryptionContextCMMInput,
 )
-from aws_cryptographic_materialproviders.mpl.references import ICryptographicMaterialsManager, IKeyring
+from aws_cryptographic_material_providers.mpl.references import ICryptographicMaterialsManager, IKeyring
 from typing import Dict, List  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/src/required_encryption_context_cmm.py
+++ b/examples/src/required_encryption_context_cmm.py
@@ -142,7 +142,7 @@ def encrypt_and_decrypt_with_keyring(
     try:
         plaintext_bytes_a, _ = client.decrypt(
             source=ciphertext,
-            materials_manager=required_ec_cmm,
+            materials_manager=underlying_cmm,
             # No reproduced encryption context for required EC CMM-produced message makes decryption fail.
         )
         raise Exception("If this exception is raised, decryption somehow succeeded!")

--- a/examples/src/set_encryption_algorithm_suite_example.py
+++ b/examples/src/set_encryption_algorithm_suite_example.py
@@ -39,10 +39,10 @@ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-raw-aes-ke
 """
 import secrets
 
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from typing import Dict  # noqa pylint: disable=wrong-import-order
 
 import aws_encryption_sdk

--- a/examples/test/test_i_custom_mpl_cmm_example.py
+++ b/examples/test/test_i_custom_mpl_cmm_example.py
@@ -3,10 +3,10 @@
 """Test suite for encryption and decryption using custom CMM."""
 import boto3
 import pytest
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 
 from ..src.custom_mpl_cmm_example import MPLCustomSigningSuiteOnlyCMM, encrypt_decrypt_with_cmm
 

--- a/performance_tests/requirements_mpl.txt
+++ b/performance_tests/requirements_mpl.txt
@@ -1,1 +1,1 @@
-aws-cryptographic-material-providers @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python
+aws-cryptographic-material-providers @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-main-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python

--- a/performance_tests/requirements_mpl.txt
+++ b/performance_tests/requirements_mpl.txt
@@ -1,1 +1,1 @@
-aws-cryptographic-materialproviders @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python
+aws-cryptographic-material-providers @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python

--- a/performance_tests/src/aws_encryption_sdk_performance_tests/keyrings/aws_kms_keyring.py
+++ b/performance_tests/src/aws_encryption_sdk_performance_tests/keyrings/aws_kms_keyring.py
@@ -4,10 +4,10 @@
 
 import aws_encryption_sdk
 import boto3
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 
 
 def create_keyring(

--- a/performance_tests/src/aws_encryption_sdk_performance_tests/keyrings/hierarchy_keyring.py
+++ b/performance_tests/src/aws_encryption_sdk_performance_tests/keyrings/hierarchy_keyring.py
@@ -4,17 +4,17 @@
 
 import aws_encryption_sdk
 import boto3
-from aws_cryptographic_materialproviders.keystore import KeyStore
-from aws_cryptographic_materialproviders.keystore.config import KeyStoreConfig
-from aws_cryptographic_materialproviders.keystore.models import KMSConfigurationKmsKeyArn
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.keystore import KeyStore
+from aws_cryptographic_material_providers.keystore.config import KeyStoreConfig
+from aws_cryptographic_material_providers.keystore.models import KMSConfigurationKmsKeyArn
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CacheTypeDefault,
     CreateAwsKmsHierarchicalKeyringInput,
     DefaultCache,
 )
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 
 from ..utils.util import PerfTestUtils
 

--- a/performance_tests/src/aws_encryption_sdk_performance_tests/keyrings/raw_aes_keyring.py
+++ b/performance_tests/src/aws_encryption_sdk_performance_tests/keyrings/raw_aes_keyring.py
@@ -3,10 +3,10 @@
 """Performance tests for the Raw AES keyring."""
 
 import aws_encryption_sdk
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import AesWrappingAlg, CreateRawAesKeyringInput
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 
 from ..utils.util import PerfTestUtils
 

--- a/performance_tests/src/aws_encryption_sdk_performance_tests/keyrings/raw_rsa_keyring.py
+++ b/performance_tests/src/aws_encryption_sdk_performance_tests/keyrings/raw_rsa_keyring.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Performance tests for the Raw RSA keyring."""
 import aws_encryption_sdk
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import CreateRawRsaKeyringInput, PaddingScheme
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import CreateRawRsaKeyringInput, PaddingScheme
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 
 
 def create_keyring(public_key, private_key):

--- a/requirements_mpl.txt
+++ b/requirements_mpl.txt
@@ -1,1 +1,1 @@
-aws-cryptographic-material-providers @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python
+aws-cryptographic-material-providers @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-main-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python

--- a/requirements_mpl.txt
+++ b/requirements_mpl.txt
@@ -1,1 +1,1 @@
-aws-cryptographic-materialproviders @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python
+aws-cryptographic-material-providers @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     extras_require={
         "MPL": ["aws-cryptographic-material-providers @" \
                 "git+https://github.com/aws/aws-cryptographic-material-providers-library.git@" \
-                "python-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python"],
+                "python-main-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python"],
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     # TODO-MPL: Point at PyPI once MPL is released.
     # This blocks releasing ESDK-Python MPL integration.
     extras_require={
-        "MPL": ["aws-cryptographic-material-providers @" \ 
+        "MPL": ["aws-cryptographic-material-providers @" \
                 "git+https://github.com/aws/aws-cryptographic-material-providers-library.git@" \
                 "python-main-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python"],
     },

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     # TODO-MPL: Point at PyPI once MPL is released.
     # This blocks releasing ESDK-Python MPL integration.
     extras_require={
-        "MPL": ["aws-cryptographic-materialproviders @" \
+        "MPL": ["aws-cryptographic-material-providers @" \
                 "git+https://github.com/aws/aws-cryptographic-material-providers-library.git@" \
                 "python-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python"],
     },

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     # TODO-MPL: Point at PyPI once MPL is released.
     # This blocks releasing ESDK-Python MPL integration.
     extras_require={
-        "MPL": ["aws-cryptographic-material-providers @" \
+        "MPL": ["aws-cryptographic-material-providers @" \ 
                 "git+https://github.com/aws/aws-cryptographic-material-providers-library.git@" \
                 "python-main-with-dafny-code#subdirectory=AwsCryptographicMaterialProviders/runtimes/python"],
     },

--- a/src/aws_encryption_sdk/__init__.py
+++ b/src/aws_encryption_sdk/__init__.py
@@ -96,10 +96,10 @@ class EncryptionSDKClient(object):
         .. code:: python
 
             >>> import boto3
-            >>> from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-            >>> from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-            >>> from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsKeyringInput
-            >>> from aws_cryptographic_materialproviders.mpl.references import IKeyring
+            >>> from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+            >>> from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+            >>> from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsKeyringInput
+            >>> from aws_cryptographic_material_providers.mpl.references import IKeyring
             >>> import aws_encryption_sdk
             >>> client = aws_encryption_sdk.EncryptionSDKClient()
             >>> mat_prov: AwsCryptographicMaterialProviders = AwsCryptographicMaterialProviders(
@@ -129,7 +129,7 @@ class EncryptionSDKClient(object):
         :type key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
         :param keyring: `IKeyring` that returns keyring for encryption
             (requires either `materials_manager` or `keyring`)
-        :type keyring: aws_cryptographic_materialproviders.mpl.references.IKeyring
+        :type keyring: aws_cryptographic_material_providers.mpl.references.IKeyring
         :param int source_length: Length of source data (optional)
 
             .. note::
@@ -164,10 +164,10 @@ class EncryptionSDKClient(object):
         .. code:: python
 
             >>> import boto3
-            >>> from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-            >>> from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-            >>> from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsKeyringInput
-            >>> from aws_cryptographic_materialproviders.mpl.references import IKeyring
+            >>> from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+            >>> from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+            >>> from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsKeyringInput
+            >>> from aws_cryptographic_material_providers.mpl.references import IKeyring
             >>> import aws_encryption_sdk
             >>> client = aws_encryption_sdk.EncryptionSDKClient()
             >>> mat_prov: AwsCryptographicMaterialProviders = AwsCryptographicMaterialProviders(
@@ -197,7 +197,7 @@ class EncryptionSDKClient(object):
         :type key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
         :param keyring: `IKeyring` that returns keyring for encryption
             (requires either `materials_manager` or `keyring`)
-        :type keyring: aws_cryptographic_materialproviders.mpl.references.IKeyring
+        :type keyring: aws_cryptographic_material_providers.mpl.references.IKeyring
         :param int source_length: Length of source data (optional)
 
             .. note::
@@ -238,10 +238,10 @@ class EncryptionSDKClient(object):
         .. code:: python
 
             >>> import boto3
-            >>> from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-            >>> from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-            >>> from aws_cryptographic_materialproviders.mpl.models import CreateAwsKmsKeyringInput
-            >>> from aws_cryptographic_materialproviders.mpl.references import IKeyring
+            >>> from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+            >>> from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+            >>> from aws_cryptographic_material_providers.mpl.models import CreateAwsKmsKeyringInput
+            >>> from aws_cryptographic_material_providers.mpl.references import IKeyring
             >>> import aws_encryption_sdk
             >>> client = aws_encryption_sdk.EncryptionSDKClient()
             >>> mat_prov: AwsCryptographicMaterialProviders = AwsCryptographicMaterialProviders(

--- a/src/aws_encryption_sdk/internal/formatting/serialize.py
+++ b/src/aws_encryption_sdk/internal/formatting/serialize.py
@@ -196,7 +196,7 @@ def _serialize_header_auth_v1(
     :type signer: aws_encryption_sdk.Signer
     :param required_encryption_context_bytes: Serialized encryption context items
         for all items whose keys are in the required_encryption_context list.
-        This is ONLY processed if using the aws-cryptographic-materialproviders library
+        This is ONLY processed if using the aws-cryptographic-material-providers library
         AND its required encryption context CMM. (optional)
     :type required_encryption_context_bytes: bytes
     :returns: Serialized header authentication data
@@ -250,7 +250,7 @@ def _serialize_header_auth_v2(
     :type signer: aws_encryption_sdk.Signer
     :param required_encryption_context_bytes: Serialized encryption context items
         for all items whose keys are in the required_encryption_context list.
-        This is ONLY processed if using the aws-cryptographic-materialproviders library
+        This is ONLY processed if using the aws-cryptographic-material-providers library
         AND its required encryption context CMM. (optional)
     :type required_encryption_context_bytes: bytes
     :returns: Serialized header authentication data
@@ -306,7 +306,7 @@ def serialize_header_auth(
     :type signer: aws_encryption_sdk.Signer
     :param required_encryption_context_bytes: Serialized encryption context items
         for all items whose keys are in the required_encryption_context list.
-        This is ONLY processed if using the aws-cryptographic-materialproviders library
+        This is ONLY processed if using the aws-cryptographic-material-providers library
         AND its required encryption context CMM. (optional)
     :type required_encryption_context_bytes: bytes
     :returns: Serialized header authentication data

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -202,7 +202,7 @@ class MasterKeyProvider(object):
         self._decrypt_key_index[key_info] = decrypt_master_key
         return decrypt_master_key
 
-    def decrypt_data_key(self, encrypted_data_key, algorithm, encryption_context):
+    def decrypt_data_key_mkp(self, encrypted_data_key, algorithm, encryption_context):
         """Iterates through all currently added Master Keys and Master Key Providers
         to attempt to decrypt data key.
 
@@ -302,7 +302,7 @@ class MasterKeyProvider(object):
         data_key = None
         for encrypted_data_key in encrypted_data_keys:
             try:
-                data_key = self.decrypt_data_key(encrypted_data_key, algorithm, encryption_context)
+                data_key = self.decrypt_data_key_mkp(encrypted_data_key, algorithm, encryption_context)
             # MasterKeyProvider.decrypt_data_key throws DecryptKeyError
             # but MasterKey.decrypt_data_key throws IncorrectMasterKeyError
             except (DecryptKeyError, IncorrectMasterKeyError):

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -12,6 +12,7 @@ from aws_encryption_sdk.exceptions import (
     ConfigMismatchError,
     DecryptKeyError,
     IncorrectMasterKeyError,
+    InvalidDataKeyError,
     InvalidKeyIdError,
     MasterKeyProviderError,
 )

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -12,6 +12,7 @@ from aws_encryption_sdk.exceptions import (
     ConfigMismatchError,
     DecryptKeyError,
     IncorrectMasterKeyError,
+    InvalidDataKeyError,
     InvalidKeyIdError,
     MasterKeyProviderError,
 )
@@ -305,7 +306,7 @@ class MasterKeyProvider(object):
                 data_key = self.decrypt_data_key_mkp(encrypted_data_key, algorithm, encryption_context)
             # MasterKeyProvider.decrypt_data_key throws DecryptKeyError
             # but MasterKey.decrypt_data_key throws IncorrectMasterKeyError
-            except (DecryptKeyError, IncorrectMasterKeyError):
+            except (DecryptKeyError, IncorrectMasterKeyError, InvalidDataKeyError):
                 continue
             else:
                 break

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -19,6 +19,8 @@ from aws_encryption_sdk.exceptions import (
 from aws_encryption_sdk.internal.str_ops import to_bytes
 from aws_encryption_sdk.structures import MasterKeyInfo
 
+import botoccre
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -257,7 +259,7 @@ class MasterKeyProvider(object):
                     # //# input encryption context.
 
                     data_key = master_key.decrypt_data_key(encrypted_data_key, algorithm, encryption_context)
-                except (IncorrectMasterKeyError, DecryptKeyError) as error:
+                except (IncorrectMasterKeyError, DecryptKeyError, InvalidDataKeyError, botocore.exceptions.ClientError) as error:
                     _LOGGER.debug(
                         "%s raised when attempting to decrypt data key with master key %s",
                         repr(error),

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -205,7 +205,7 @@ class MasterKeyProvider(object):
         self._decrypt_key_index[key_info] = decrypt_master_key
         return decrypt_master_key
 
-    def decrypt_data_key_mkp(self, encrypted_data_key, algorithm, encryption_context):
+    def decrypt_data_key_as_provider(self, encrypted_data_key, algorithm, encryption_context):
         """Iterates through all currently added Master Keys and Master Key Providers
         to attempt to decrypt data key.
 
@@ -305,7 +305,7 @@ class MasterKeyProvider(object):
         data_key = None
         for encrypted_data_key in encrypted_data_keys:
             try:
-                data_key = self.decrypt_data_key_mkp(encrypted_data_key, algorithm, encryption_context)
+                data_key = self.decrypt_data_key_as_provider(encrypted_data_key, algorithm, encryption_context)
             # MasterKeyProvider.decrypt_data_key throws DecryptKeyError
             # but MasterKey.decrypt_data_key throws IncorrectMasterKeyError
             except (DecryptKeyError, IncorrectMasterKeyError, InvalidDataKeyError):

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -256,7 +256,7 @@ class MasterKeyProvider(object):
                     # //# input encryption context.
 
                     data_key = master_key.decrypt_data_key(encrypted_data_key, algorithm, encryption_context)
-                except (IncorrectMasterKeyError, DecryptKeyError) as error:
+                except (IncorrectMasterKeyError, DecryptKeyError, InvalidDataKeyError) as error:
                     _LOGGER.debug(
                         "%s raised when attempting to decrypt data key with master key %s",
                         repr(error),
@@ -304,8 +304,8 @@ class MasterKeyProvider(object):
             try:
                 data_key = self.decrypt_data_key(encrypted_data_key, algorithm, encryption_context)
             # MasterKeyProvider.decrypt_data_key throws DecryptKeyError
-            # but MasterKey.decrypt_data_key throws IncorrectMasterKeyError
-            except (DecryptKeyError, IncorrectMasterKeyError):
+            # but MasterKey.decrypt_data_key throws IncorrectMasterKeyError and InvalidDataKeyError
+            except (DecryptKeyError, IncorrectMasterKeyError, InvalidDataKeyError):
                 continue
             else:
                 break

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -19,7 +19,7 @@ from aws_encryption_sdk.exceptions import (
 from aws_encryption_sdk.internal.str_ops import to_bytes
 from aws_encryption_sdk.structures import MasterKeyInfo
 
-import botoccre
+import botocore
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/aws_encryption_sdk/materials_managers/__init__.py
+++ b/src/aws_encryption_sdk/materials_managers/__init__.py
@@ -80,7 +80,7 @@ class DecryptionMaterialsRequest(object):
     :type encrypted_data_keys: set of `aws_encryption_sdk.structures.EncryptedDataKey`
     :param dict encryption_context: Encryption context to provide to master keys for underlying decrypt requests
     :param dict reproduced_encryption_context: Encryption context to provide on decrypt.
-        This is ONLY processed if using a CMM from the aws-cryptographic-materialproviders library.
+        This is ONLY processed if using a CMM from the aws-cryptographic-material-providers library.
     """
 
     algorithm = attr.ib(validator=attr.validators.instance_of(Algorithm))

--- a/src/aws_encryption_sdk/materials_managers/mpl/cmm.py
+++ b/src/aws_encryption_sdk/materials_managers/mpl/cmm.py
@@ -7,11 +7,11 @@ The aws-cryptographic-materials-library MUST be installed to use this module.
 # pylint should pass even if the MPL isn't installed
 # Also thinks these imports aren't used if it can't import them
 # noqa pylint: disable=import-error,unused-import
-from aws_cryptographic_materialproviders.mpl.errors import (
+from aws_cryptographic_material_providers.mpl.errors import (
     AwsCryptographicMaterialProvidersException,
     CollectionOfErrors,
 )
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl.models import (
     AlgorithmSuiteIdESDK as MPL_AlgorithmSuiteIdESDK,
     CommitmentPolicyESDK as MPL_CommitmentPolicyESDK,
     DecryptMaterialsInput as MPL_DecryptMaterialsInput,
@@ -20,7 +20,7 @@ from aws_cryptographic_materialproviders.mpl.models import (
     GetEncryptionMaterialsInput as MPL_GetEncryptionMaterialsInput,
     GetEncryptionMaterialsOutput as MPL_GetEncryptionMaterialsOutput,
 )
-from aws_cryptographic_materialproviders.mpl.references import (
+from aws_cryptographic_material_providers.mpl.references import (
     ICryptographicMaterialsManager as MPL_ICryptographicMaterialsManager,
 )
 # noqa pylint: enable=import-error,unused-import
@@ -38,7 +38,7 @@ from aws_encryption_sdk.structures import EncryptedDataKey as Native_EncryptedDa
 class CryptoMaterialsManagerFromMPL(CryptoMaterialsManager):
     """
     In instances where encryption materials are provided by an implementation of the MPL's
-    `aws_cryptographic_materialproviders.mpl.references.MPL_ICryptographicMaterialsManager`,
+    `aws_cryptographic_material_providers.mpl.references.MPL_ICryptographicMaterialsManager`,
     this maps the ESDK-Python CMM interfaces to the MPL CMM.
     """
 

--- a/src/aws_encryption_sdk/materials_managers/mpl/materials.py
+++ b/src/aws_encryption_sdk/materials_managers/mpl/materials.py
@@ -6,7 +6,7 @@ The aws-cryptographic-materials-library MUST be installed to use this module.
 """
 # pylint should pass even if the MPL isn't installed
 # noqa pylint: disable=import-error
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl.models import (
     DecryptionMaterials as MPL_DecryptionMaterials,
     EncryptedDataKey as MPL_EncryptedDataKey,
     EncryptionMaterials as MPL_EncryptionMaterials,
@@ -30,7 +30,7 @@ def _mpl_algorithm_id_to_native_algorithm_id(mpl_algorithm_id: str) -> int:
 class EncryptionMaterialsFromMPL(Native_EncryptionMaterials):
     """
     In instances where encryption materials are be provided by
-    the MPL's `aws_cryptographic_materialproviders.mpl.models.EncryptionMaterials`,
+    the MPL's `aws_cryptographic_material_providers.mpl.models.EncryptionMaterials`,
     this maps the ESDK interfaces to the underlying MPL materials.
     """
 
@@ -107,7 +107,7 @@ class EncryptionMaterialsFromMPL(Native_EncryptionMaterials):
 class DecryptionMaterialsFromMPL(Native_DecryptionMaterials):
     """
     In instances where decryption materials are be provided by
-    the MPL's `aws_cryptographic_materialproviders.mpl.models.DecryptionMaterials`,
+    the MPL's `aws_cryptographic_material_providers.mpl.models.DecryptionMaterials`,
     this maps the ESDK interfaces to the underlying MPL materials.
     """
 

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -63,11 +63,11 @@ from aws_encryption_sdk.structures import MessageHeader
 try:
     # pylint should pass even if the MPL isn't installed
     # noqa pylint: disable=import-error
-    from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-    from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-    from aws_cryptographic_materialproviders.mpl.errors import AwsCryptographicMaterialProvidersException
-    from aws_cryptographic_materialproviders.mpl.models import CreateDefaultCryptographicMaterialsManagerInput
-    from aws_cryptographic_materialproviders.mpl.references import (
+    from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+    from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+    from aws_cryptographic_material_providers.mpl.errors import AwsCryptographicMaterialProvidersException
+    from aws_cryptographic_material_providers.mpl.models import CreateDefaultCryptographicMaterialsManagerInput
+    from aws_cryptographic_material_providers.mpl.references import (
         ICryptographicMaterialsManager as MPL_ICryptographicMaterialsManager,
         IKeyring as MPL_IKeyring,
     )
@@ -425,10 +425,10 @@ class EncryptorConfig(_ClientConfig):
     :param key_provider: `MasterKeyProvider` from which to obtain data keys for encryption
         (either `materials_manager` or `key_provider` required)
     :type key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
-    :param keyring: `IKeyring` from the aws_cryptographic_materialproviders library
+    :param keyring: `IKeyring` from the aws_cryptographic_material_providers library
         which handles encryption and decryption
     :type keyring:
-        aws_cryptographic_materialproviders.mpl.references.IKeyring
+        aws_cryptographic_material_providers.mpl.references.IKeyring
     :param int source_length: Length of source data (optional)
 
         .. note::
@@ -480,10 +480,10 @@ class StreamEncryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
     :param key_provider: `MasterKeyProvider` from which to obtain data keys for encryption
         (either `materials_manager` or `key_provider` required)
     :type key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
-    :param keyring: `IKeyring` from the aws_cryptographic_materialproviders library
+    :param keyring: `IKeyring` from the aws_cryptographic_material_providers library
         which handles encryption and decryption
     :type keyring:
-        aws_cryptographic_materialproviders.mpl.references.IKeyring
+        aws_cryptographic_material_providers.mpl.references.IKeyring
     :param int source_length: Length of source data (optional)
 
         .. note::
@@ -867,10 +867,10 @@ class DecryptorConfig(_ClientConfig):
     :param key_provider: `MasterKeyProvider` from which to obtain data keys for decryption
         (either `keyring`, `materials_manager` or `key_provider` required)
     :type key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
-    :param keyring: `IKeyring` from the aws_cryptographic_materialproviders library
+    :param keyring: `IKeyring` from the aws_cryptographic_material_providers library
         which handles encryption and decryption
     :type keyring:
-        aws_cryptographic_materialproviders.mpl.references.IKeyring
+        aws_cryptographic_material_providers.mpl.references.IKeyring
     :param int source_length: Length of source data (optional)
 
         .. note::
@@ -915,10 +915,10 @@ class StreamDecryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
     :param key_provider: `MasterKeyProvider` from which to obtain data keys for decryption
         (either `materials_manager` or `key_provider` required)
     :type key_provider: aws_encryption_sdk.key_providers.base.MasterKeyProvider
-    :param keyring: `IKeyring` from the aws_cryptographic_materialproviders library
+    :param keyring: `IKeyring` from the aws_cryptographic_material_providers library
         which handles encryption and decryption
     :type keyring:
-        aws_cryptographic_materialproviders.mpl.references.IKeyring
+        aws_cryptographic_material_providers.mpl.references.IKeyring
     :param int source_length: Length of source data (optional)
 
         .. note::

--- a/test/mpl/integ/test_required_ec_cmm.py
+++ b/test/mpl/integ/test_required_ec_cmm.py
@@ -3,9 +3,9 @@
 import copy
 
 import pytest
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CreateDefaultCryptographicMaterialsManagerInput,
     CreateRequiredEncryptionContextCMMInput,
 )

--- a/test/mpl/unit/test_material_managers_mpl_cmm.py
+++ b/test/mpl/unit/test_material_managers_mpl_cmm.py
@@ -6,8 +6,8 @@ The aws-cryptographic-materials-library MUST be installed to run tests in this m
 """
 
 import pytest
-from aws_cryptographic_materialproviders.mpl.errors import AwsCryptographicMaterialProvidersException
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl.errors import AwsCryptographicMaterialProvidersException
+from aws_cryptographic_material_providers.mpl.models import (
     AlgorithmSuiteIdESDK as MPL_AlgorithmSuiteIdESDK,
     CommitmentPolicyESDK as MPL_CommitmentPolicyESDK,
     DecryptionMaterials as MPL_DecryptionMaterials,
@@ -16,7 +16,7 @@ from aws_cryptographic_materialproviders.mpl.models import (
     GetEncryptionMaterialsInput as MPL_GetEncryptionMaterialsInput,
     GetEncryptionMaterialsOutput as MPL_GetEncryptionMaterialsOutput,
 )
-from aws_cryptographic_materialproviders.mpl.references import (
+from aws_cryptographic_material_providers.mpl.references import (
     ICryptographicMaterialsManager as MPL_ICryptographicMaterialsManager,
 )
 from mock import MagicMock, patch

--- a/test/mpl/unit/test_material_managers_mpl_materials.py
+++ b/test/mpl/unit/test_material_managers_mpl_materials.py
@@ -6,7 +6,7 @@ The aws-cryptographic-materials-library MUST be installed to run tests in this m
 """
 
 import pytest
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl.models import (
     DecryptionMaterials as MPL_DecryptionMaterials,
     EncryptedDataKey as MPL_EncryptedDataKey,
     EncryptionMaterials as MPL_EncryptionMaterials,

--- a/test/mpl/utils.py
+++ b/test/mpl/utils.py
@@ -5,12 +5,12 @@ import secrets
 import string
 
 import boto3
-from aws_cryptographic_materialproviders.keystore import KeyStore
-from aws_cryptographic_materialproviders.keystore.config import KeyStoreConfig
-from aws_cryptographic_materialproviders.keystore.models import KMSConfigurationKmsKeyArn
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.keystore import KeyStore
+from aws_cryptographic_material_providers.keystore.config import KeyStoreConfig
+from aws_cryptographic_material_providers.keystore.models import KMSConfigurationKmsKeyArn
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     AesWrappingAlg,
     CacheTypeDefault,
     CreateAwsKmsHierarchicalKeyringInput,
@@ -21,7 +21,7 @@ from aws_cryptographic_materialproviders.mpl.models import (
     DefaultCache,
     PaddingScheme,
 )
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl.references import IKeyring
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/test/unit/test_streaming_client_configs.py
+++ b/test/unit/test_streaming_client_configs.py
@@ -23,7 +23,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 # Ideally, this logic would be based on mocking imports and testing logic,
 # but doing that introduces errors that cause other tests to fail.
 try:
-    from aws_cryptographic_materialproviders.mpl.references import ICryptographicMaterialsManager, IKeyring
+    from aws_cryptographic_material_providers.mpl.references import ICryptographicMaterialsManager, IKeyring
     HAS_MPL = True
 
     from aws_encryption_sdk.materials_managers.mpl.cmm import CryptoMaterialsManagerFromMPL

--- a/test/unit/test_streaming_client_mpl_import.py
+++ b/test/unit/test_streaming_client_mpl_import.py
@@ -13,7 +13,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 # Ideally, this logic would be based on mocking imports and testing logic,
 # but doing that introduces errors that cause other tests to fail.
 try:
-    import aws_cryptographic_materialproviders  # noqa pylint: disable=unused-import
+    import aws_cryptographic_material_providers  # noqa pylint: disable=unused-import
     HAS_MPL = True
 except ImportError:
     HAS_MPL = False

--- a/test_vector_handlers/requirements_mpl.txt
+++ b/test_vector_handlers/requirements_mpl.txt
@@ -1,1 +1,1 @@
-aws-cryptography-internal-mpl-testvectors @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-with-dafny-code#subdirectory=TestVectorsAwsCryptographicMaterialProviders/runtimes/python
+aws-cryptography-internal-mpl-testvectors @ git+https://github.com/aws/aws-cryptographic-material-providers-library.git@python-main-with-dafny-code#subdirectory=TestVectorsAwsCryptographicMaterialProviders/runtimes/python

--- a/test_vector_handlers/src/awses_test_vectors/commands/full_message_decrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/commands/full_message_decrypt.py
@@ -6,7 +6,7 @@ import argparse
 from awses_test_vectors.manifests.full_message.decrypt import MessageDecryptionManifest
 
 try:
-    import aws_cryptographic_materialproviders  # noqa pylint: disable=unused-import,import-error
+    import aws_cryptographic_material_providers  # noqa pylint: disable=unused-import,import-error
     _HAS_MPL = True
 except ImportError:
     _HAS_MPL = False

--- a/test_vector_handlers/src/awses_test_vectors/commands/full_message_decrypt_generate.py
+++ b/test_vector_handlers/src/awses_test_vectors/commands/full_message_decrypt_generate.py
@@ -6,7 +6,7 @@ import argparse
 from awses_test_vectors.manifests.full_message.decrypt_generation import MessageDecryptionGenerationManifest
 
 try:
-    import aws_cryptographic_materialproviders  # noqa pylint: disable=unused-import,import-error
+    import aws_cryptographic_material_providers  # noqa pylint: disable=unused-import,import-error
     _HAS_MPL = True
 except ImportError:
     _HAS_MPL = False

--- a/test_vector_handlers/src/awses_test_vectors/commands/full_message_encrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/commands/full_message_encrypt.py
@@ -6,7 +6,7 @@ import argparse
 from awses_test_vectors.manifests.full_message.encrypt import MessageEncryptionManifest
 
 try:
-    import aws_cryptographic_materialproviders  # noqa pylint: disable=unused-import,import-error
+    import aws_cryptographic_material_providers  # noqa pylint: disable=unused-import,import-error
     _HAS_MPL = True
 except ImportError:
     _HAS_MPL = False

--- a/test_vector_handlers/src/awses_test_vectors/internal/mpl/tampering_mpl_materials.py
+++ b/test_vector_handlers/src/awses_test_vectors/internal/mpl/tampering_mpl_materials.py
@@ -16,9 +16,9 @@ from aws_encryption_sdk.materials_managers.mpl.materials import (
 from aws_encryption_sdk.materials_managers.mpl.cmm import (
     CryptoMaterialsManagerFromMPL
 )
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.models import (
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.models import (
     CreateDefaultCryptographicMaterialsManagerInput,
 )
 

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
@@ -29,10 +29,10 @@ from awses_test_vectors.manifests.master_key import MasterKeySpec, master_key_pr
 
 try:
     from awses_test_vectors.manifests.mpl_keyring import KeyringSpec, keyring_from_master_key_specs
-    from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-    from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-    from aws_cryptographic_materialproviders.mpl.references import ICryptographicMaterialsManager
-    from aws_cryptographic_materialproviders.mpl.models import (
+    from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+    from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+    from aws_cryptographic_material_providers.mpl.references import ICryptographicMaterialsManager
+    from aws_cryptographic_material_providers.mpl.models import (
         CreateDefaultCryptographicMaterialsManagerInput,
         CreateRequiredEncryptionContextCMMInput,
     )

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt_generation.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt_generation.py
@@ -19,12 +19,12 @@ from aws_encryption_sdk.materials_managers.caching import CachingCryptoMaterials
 from aws_encryption_sdk.materials_managers.default import DefaultCryptoMaterialsManager
 
 try:
-    from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-    from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-    from aws_cryptographic_materialproviders.mpl.references import (
+    from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+    from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+    from aws_cryptographic_material_providers.mpl.references import (
         IKeyring,
     )
-    from aws_cryptographic_materialproviders.mpl.models import (
+    from aws_cryptographic_material_providers.mpl.models import (
         CreateDefaultCryptographicMaterialsManagerInput,
     )
     from aws_encryption_sdk.materials_managers.mpl.cmm import CryptoMaterialsManagerFromMPL

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/encrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/encrypt.py
@@ -33,7 +33,7 @@ except ImportError:
     from aws_encryption_sdk.identifiers import Algorithm as AlgorithmSuite
 
 try:
-    from aws_cryptographic_materialproviders.mpl.references import (
+    from aws_cryptographic_material_providers.mpl.references import (
         IKeyring,
     )
 

--- a/test_vector_handlers/src/awses_test_vectors/manifests/master_key.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/master_key.py
@@ -15,7 +15,7 @@ from aws_encryption_sdk.key_providers.kms import (  # noqa pylint: disable=unuse
     KMSMasterKey,
     MRKAwareDiscoveryAwsKmsMasterKeyProvider,
 )
-from aws_encryption_sdk.key_providers.raw import RawMasterKey, RawMasterKeyProvider
+from aws_encryption_sdk.key_providers.raw import RawMasterKey
 
 from awses_test_vectors.internal.aws_kms import KMS_MASTER_KEY_PROVIDER, KMS_MRK_AWARE_MASTER_KEY_PROVIDER
 from awses_test_vectors.internal.util import membership_validator

--- a/test_vector_handlers/src/awses_test_vectors/manifests/master_key.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/master_key.py
@@ -74,7 +74,7 @@ class TestVectorsMultiMasterKeyProvider(MasterKeyProvider):
     "A master key MUST supply itself and MUST NOT supply any other master keys."
     https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/master-key-interface.md#get-master-key
     
-    
+
     """
 
     _config_class = MasterKeyProviderConfig
@@ -338,8 +338,7 @@ def master_key_provider_from_master_key_specs(keys, master_key_specs):
             pass
     if len(master_keys) == 0:
         return None
-    # master_key_ids = [master_key.key_id for master_key in master_keys]
     mkp = TestVectorsMultiMasterKeyProvider()
     for master_key in master_keys:
-        mkp.add_key(master_key.key_id, master_key)
+        mkp.add_key(master_key)
     return mkp

--- a/test_vector_handlers/src/awses_test_vectors/manifests/master_key.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/master_key.py
@@ -64,16 +64,21 @@ _RAW_ENCRYPTION_KEY_TYPE = {
 }
 
 class TestVectorsMultiMasterKeyProvider(MasterKeyProvider):
+    """
+    Provider for other MasterKeyProviders.
+    Allows a "multi" MasterKeyProvider for use in test vectors.
+
+    In Python ESDK, MasterKey extends MasterKeyProvider.
+    However, MasterKey overrides MasterKeyProvider's `decrypt_data_key` method.
+    From AWS ESDK specification:
+    "A master key MUST supply itself and MUST NOT supply any other master keys."
+    https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/master-key-interface.md#get-master-key
+    
+    
+    """
 
     _config_class = MasterKeyProviderConfig
     provider_id = "aws-test-vectors-multi-master-key-provider"
-
-    # @attr.s
-    # class _MultiMasterKeyProviderConfig(MasterKeyProviderConfig):
-    #     key_provider_for_key_id = {}
-
-    # provider_id = "aws-test-vectors"
-    # _config_class = _RawMultiMKPConfig
 
     def __init__(self):
         self.key_provider_for_key_id = {}
@@ -83,76 +88,6 @@ class TestVectorsMultiMasterKeyProvider(MasterKeyProvider):
 
     def _new_master_key(self, key_id):
         raise InvalidKeyIdError()
-
-
-# class StaticRawMasterKeyProvider(RawMasterKeyProvider):
-#     """Provides a primary master key and others."""
-
-#     def __init__(self, raw_master_key):  # pylint: disable=unused-argument
-#         """Initialize empty map of keys."""
-#         self.raw_master_key = raw_master_key
-        
-#     def add_primary_key(self, primary_key):
-#         self._primary_key = primary_key
-#         self.add_master_key(primary_key)
-
-#     def add_other_key(self, other_key):
-#         self._other_keys.append(other_key)
-#         self.add_master_key(other_key)
-
-#     def _get_raw_key(self, key_id):
-#         """Returns a static, randomly-generated symmetric key for the specified key ID.
-
-#         :param str key_id: Key ID
-#         :returns: Wrapping key that contains the specified static key
-#         :rtype: :class:`aws_encryption_sdk.internal.crypto.WrappingKey`
-#         """
-#         try:
-#             static_key = self._static_keys[key_id]
-#         except KeyError:
-#             raise IncorrectMasterKeyError(f"StaticMasterKeyProvider does not have key_id={key_id}")
-#         return WrappingKey(
-#             wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
-#             wrapping_key=static_key,
-#             wrapping_key_type=EncryptionKeyType.SYMMETRIC,
-#         )
-
-# This is a helper class necessary for the Raw AES master key provider
-# In the StaticMasterKeyProvider, we fix the static key to
-# DEFAULT_AES_256_STATIC_KEY in order to make the test deterministic.
-# Thus, both the Raw AES keyring and Raw AES MKP have the same key
-# and we are able to encrypt data using keyrings and decrypt using MKP and vice versa
-# In practice, users should generate a new random key for each key id.
-# class StaticMasterKeyProvider(RawMasterKeyProvider):
-#     """Generates 256-bit keys for each unique key ID."""
-
-#     # The key namespace in the Raw keyrings is equivalent to Provider ID (or Provider) field
-#     # in the Raw Master Key Providers
-#     provider_id = DEFAULT_KEY_NAME_SPACE
-
-#     def __init__(self, **kwargs):  # pylint: disable=unused-argument
-#         """Initialize empty map of keys."""
-#         self._static_keys = {}
-
-#     def add_key(self, key):
-#         self._static_keys[key_id]
-
-#     def _get_raw_key(self, key_id):
-#         """Returns a static, symmetric key for the specified key ID.
-
-#         :param str key_id: Key ID
-#         :returns: Wrapping key that contains the specified static key
-#         :rtype: :class:`aws_encryption_sdk.internal.crypto.WrappingKey`
-#         """
-#         try:
-#             static_key = self._static_keys[key_id]
-#         except KeyError:
-#             raise IncorrectMasterKeyError(f"StaticMasterKeyProvider does not have key_id={key_id}")
-#         return WrappingKey(
-#             wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
-#             wrapping_key=static_key,
-#             wrapping_key_type=EncryptionKeyType.SYMMETRIC,
-#         )
 
 @attr.s
 class MasterKeySpec(object):  # pylint: disable=too-many-instance-attributes
@@ -287,7 +222,6 @@ class MasterKeySpec(object):  # pylint: disable=too-many-instance-attributes
 
         key_spec = keys.key(self.key_name)
         wrapping_key = self._wrapping_key(key_spec)
-        print(f"_raw_master_key_from_spec {self.key_name=} {key_spec=}")
         return RawMasterKey(provider_id=self.provider_id, key_id=key_spec.key_id, wrapping_key=wrapping_key)
 
     def _kms_master_key_from_spec(self, keys):
@@ -395,7 +329,6 @@ def master_key_provider_from_master_key_specs(keys, master_key_specs):
     """
     master_keys = []
     for spec in master_key_specs:
-        print(f"{spec=}")
         try:
             master_keys.append(spec.master_key(keys))
         # If spec is not a valid master key
@@ -405,14 +338,8 @@ def master_key_provider_from_master_key_specs(keys, master_key_specs):
             pass
     if len(master_keys) == 0:
         return None
-    print(master_keys)
     # master_key_ids = [master_key.key_id for master_key in master_keys]
     mkp = TestVectorsMultiMasterKeyProvider()
     for master_key in master_keys:
-        mkp.add_key(master_key)
-    # primary = master_keys[0]
-    # mkp.add_key(primary.key_id, primary)
-    # others = master_keys[1:]
-    # for master_key in others:
-    #     mkp.add_key(master_key.key_id, master_key)
+        mkp.add_key(master_key.key_id, master_key)
     return mkp

--- a/test_vector_handlers/src/awses_test_vectors/manifests/mpl_keyring.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/mpl_keyring.py
@@ -180,8 +180,7 @@ class KeyringSpec(MasterKeySpec):  # pylint: disable=too-many-instance-attribute
         # But this seems weird, and we didn't have to do this in Java.
         if hasattr(keyring, "_impl"):  # pylint: disable=protected-access
             if hasattr(keyring._impl, "_keyName"):  # pylint: disable=protected-access
-                if keyring._impl._keyName == UTF8.default__.Encode(_dafny.Seq("rsa-4096-public")).value \
-                        and mode in ("decrypt-generate", "encrypt"):  # pylint: disable=protected-access
+                if keyring._impl._keyName == UTF8.default__.Encode(_dafny.Seq("rsa-4096-public")).value:
                     if changed_key_name_from_private_to_public:
                         # pylint: disable=protected-access
                         keyring._impl._keyName = UTF8.default__.Encode(_dafny.Seq("rsa-4096-private")).value

--- a/test_vector_handlers/src/awses_test_vectors/manifests/mpl_keyring.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/mpl_keyring.py
@@ -25,10 +25,10 @@ from aws_cryptography_materialproviders_test_vectors.smithygenerated.\
         GetKeyDescriptionOutput,
         TestVectorKeyringInput,
     )
-from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_material_providers.mpl.references import IKeyring
-from aws_cryptographic_material_providers.mpl.models import CreateMultiKeyringInput
+from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_materialproviders.mpl.references import IKeyring
+from aws_cryptographic_materialproviders.mpl.models import CreateMultiKeyringInput
 
 import _dafny
 from smithy_dafny_standard_library.internaldafny.generated import UTF8
@@ -180,7 +180,8 @@ class KeyringSpec(MasterKeySpec):  # pylint: disable=too-many-instance-attribute
         # But this seems weird, and we didn't have to do this in Java.
         if hasattr(keyring, "_impl"):  # pylint: disable=protected-access
             if hasattr(keyring._impl, "_keyName"):  # pylint: disable=protected-access
-                if keyring._impl._keyName == UTF8.default__.Encode(_dafny.Seq("rsa-4096-public")).value:
+                if keyring._impl._keyName == UTF8.default__.Encode(_dafny.Seq("rsa-4096-public")).value \
+                        and mode in ("decrypt-generate", "encrypt"):  # pylint: disable=protected-access
                     if changed_key_name_from_private_to_public:
                         # pylint: disable=protected-access
                         keyring._impl._keyName = UTF8.default__.Encode(_dafny.Seq("rsa-4096-private")).value

--- a/test_vector_handlers/src/awses_test_vectors/manifests/mpl_keyring.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/mpl_keyring.py
@@ -25,10 +25,10 @@ from aws_cryptography_materialproviders_test_vectors.smithygenerated.\
         GetKeyDescriptionOutput,
         TestVectorKeyringInput,
     )
-from aws_cryptographic_materialproviders.mpl import AwsCryptographicMaterialProviders
-from aws_cryptographic_materialproviders.mpl.config import MaterialProvidersConfig
-from aws_cryptographic_materialproviders.mpl.references import IKeyring
-from aws_cryptographic_materialproviders.mpl.models import CreateMultiKeyringInput
+from aws_cryptographic_material_providers.mpl import AwsCryptographicMaterialProviders
+from aws_cryptographic_material_providers.mpl.config import MaterialProvidersConfig
+from aws_cryptographic_material_providers.mpl.references import IKeyring
+from aws_cryptographic_material_providers.mpl.models import CreateMultiKeyringInput
 
 import _dafny
 from smithy_dafny_standard_library.internaldafny.generated import UTF8


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Three changes:
* Rename MPL from `aws-cryptographic-materialproviders` to  `aws-cryptographic-material-providers`, same for `_`
* Merge from `master`; this gets [this commit](https://github.com/aws/aws-encryption-sdk-python/commit/61953f16961a111205626c8c096c5ce66747ef44)

It would be great if these could be separate PRs, but they can't. CI will only pass with both of these changes.

The third change could be its own PR, but it's just one line:
* Provide correct CMM in a required EC CMM example test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

