### PR TITLE
chore(CI): Fix TestVectors timeout

### DIFF
--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
@@ -630,21 +630,11 @@ class MessageDecryptionManifest(object):
         client_name = raw_manifest["client"]["name"]  # type: str
         client_version = raw_manifest["client"]["version"]  # type: str
         raw_scenarios = raw_manifest["tests"]  # type: Dict[str, DECRYPT_SCENARIO_SPEC]
-        test_scenarios = {
-            name: MessageDecryptionTestScenario.from_scenario(
-                scenario=scenario,
-                plaintext_reader=root_reader,
-                ciphertext_reader=root_reader,
-                keys=keys,
-                keyrings=False,
-                keys_uri=keys_abs_path,
-            )
-            for name, scenario in raw_scenarios.items()
-        }
-        # If optional keyrings argument is true,
-        # also add scenarios to decrypt with keyrings.
+
+        # If optional keyrings argument is specified,
+        # decrypt with keyrings
         if keyrings:
-            keyrings_test_scenarios = {
+            test_scenarios = {
                 name + "-keyring": MessageDecryptionTestScenario.from_scenario(
                     scenario=scenario,
                     plaintext_reader=root_reader,
@@ -655,8 +645,20 @@ class MessageDecryptionManifest(object):
                 )
                 for name, scenario in raw_scenarios.items()
             }
-            # Merge keyring scenarios into test_scenarios
-            test_scenarios = {**keyrings_test_scenarios, **test_scenarios}
+        # If optional keyrings argument is not specified,
+        # decrypt with master key providers
+        else:
+            test_scenarios = {
+                name: MessageDecryptionTestScenario.from_scenario(
+                    scenario=scenario,
+                    plaintext_reader=root_reader,
+                    ciphertext_reader=root_reader,
+                    keys=keys,
+                    keyrings=False,
+                    keys_uri=keys_abs_path,
+                )
+                for name, scenario in raw_scenarios.items()
+            }
 
         # Remove any `None` scenarios from test scenarios.
         # `None` scenarios indicate the loader determined the scenario is invalid.

--- a/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
+++ b/test_vector_handlers/src/awses_test_vectors/manifests/full_message/decrypt.py
@@ -646,7 +646,7 @@ class MessageDecryptionManifest(object):
                 for name, scenario in raw_scenarios.items()
             }
         # If optional keyrings argument is not specified,
-        # decrypt with master key providers
+        # decrypt with master key providers.
         else:
             test_scenarios = {
                 name: MessageDecryptionTestScenario.from_scenario(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix a timeout in TestVectors by removing redundant test scenarios.

CodeBuild CI has tests that decrypt generated vectors with both keyrings and MKPs.
However, the keyrings step actually decrypts with *both* keyrings and MKPs.
This change removes the MKP decryption from the keyrings step, since it is redundant.

This change fixes a timeout in CodeBuild CI.
CodeBuild CI times out after 60 minutes.
Before this change, CI would time out at roughly 60 minutes, but would sometimes succeed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

