### PR TITLE
chore(CI): Bump from macOS 12 to 13

### DIFF
--- a/.github/workflows/ci_test-vector-handler.yaml
+++ b/.github/workflows/ci_test-vector-handler.yaml
@@ -19,7 +19,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-12
+          - macos-13
         python:
           - 3.8
           - 3.x
@@ -34,7 +34,7 @@ jobs:
           # x86 builds are only meaningful for Windows
           - os: ubuntu-latest
             architecture: x86
-          - os: macos-12
+          - os: macos-13
             architecture: x86
     steps:
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -26,7 +26,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-12
+          - macos-13
         python:
           - 3.8
           - 3.9
@@ -48,7 +48,7 @@ jobs:
           # x86 builds are only meaningful for Windows
           - os: ubuntu-latest
             architecture: x86
-          - os: macos-12
+          - os: macos-13
             architecture: x86
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

