### PR TITLE
chore: Increase timeout for CodeBuild CI

### DIFF
--- a/.github/workflows/ci_codebuild-tests.yml
+++ b/.github/workflows/ci_codebuild-tests.yml
@@ -38,10 +38,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
-          role-duration-seconds: 3600
+          role-duration-seconds: 4200
       - name: Run python-${{ matrix.python.python_version }} ${{ matrix.codebuild_file_name }}
         uses: aws-actions/aws-codebuild-run-build@v1
-        timeout-minutes: 60
+        timeout-minutes: 70
         with:
           project-name: python-esdk
           buildspec-override: codebuild/py${{ matrix.python.python_version }}/${{ matrix.codebuild_file_name }}

--- a/.github/workflows/ci_codebuild-tests.yml
+++ b/.github/workflows/ci_codebuild-tests.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
-          role-duration-seconds: 3600
+          role-duration-seconds: 4200
       - name: Run python-${{ matrix.python.python_version }} ${{ matrix.codebuild_file_name }}
         uses: aws-actions/aws-codebuild-run-build@v1
         timeout-minutes: 70

--- a/.github/workflows/ci_codebuild-tests.yml
+++ b/.github/workflows/ci_codebuild-tests.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
-          role-duration-seconds: 4200
+          role-duration-seconds: 3600
       - name: Run python-${{ matrix.python.python_version }} ${{ matrix.codebuild_file_name }}
         uses: aws-actions/aws-codebuild-run-build@v1
         timeout-minutes: 70


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The CodeBuild CI change I deployed yesterday takes 55-60 minutes and times out at 60 minutes.
Bump the timeout slightly to prevent flaky CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

