### PR TITLE
chore(deps-release): bump twine from 4.0.1 to 5.1.1

### DIFF
--- a/dev_requirements/release-requirements.txt
+++ b/dev_requirements/release-requirements.txt
@@ -1,4 +1,4 @@
 pypi-parker==0.1.2
 setuptools==66.1.1
-twine==4.0.1
+twine==5.1.1
 wheel==0.38.4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`twine` needs a MV bump since the last ESDK-Python release.
ESDK-Python 4.0.0 release failed with the errors described in https://github.com/astral-sh/rye/issues/1180
One solution described there is to bump `twine`.
This PR bumps `twine` to `5.1.1` (same version used by MPL-Python).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

