### PR TITLE
chore: remove SECT409K1 from test

### DIFF
--- a/test/unit/test_crypto.py
+++ b/test/unit/test_crypto.py
@@ -36,14 +36,6 @@ VALUES = {
         b"\n:\xcaD\x1f)\xde\xf73\x9a!/x#(z\xf8/\x83\xeb\r&\x7f&\xb4\xeb\xc1\x1b\xe9\x91I\xf5\x8a\xb6\xee\xaf\x08\xb9"
         b"\xa5\xe1S\xb2Gw\x15(\xb6\xe1"
     ),
-    "ecc_private_key_char2": ec.EllipticCurvePrivateNumbers(
-        private_value=131512833187976200862897177240257889476359607892474090119002870596121284569326171944650239612201181144875264734209664973820,  # noqa pylint: disable=line-too-long
-        public_numbers=ec.EllipticCurvePublicNumbers(
-            x=783372629152728216190118671643020486604880277607267246139026062120084499867233383227220456289236528291350315438332972681898,  # noqa pylint: disable=line-too-long
-            y=657053766035459398820670308946963262342583342616783849689721971058264156234178067988487273332138651529574836305189297847674,  # noqa pylint: disable=line-too-long
-            curve=ec.SECT409K1(),
-        ),
-    ).private_key(default_backend()),
 }
 VALUES["ciphertext"] = VALUES["encryptor"]["update"] + VALUES["encryptor"]["finalize"]
 VALUES["plaintext"] = VALUES["decryptor"]["update"] + VALUES["decryptor"]["finalize"]

--- a/test/unit/test_crypto_elliptic_curve.py
+++ b/test/unit/test_crypto_elliptic_curve.py
@@ -287,13 +287,6 @@ def test_ecc_encode_compressed_point_prime():
     assert compressed_point == VALUES["ecc_compressed_point"]
 
 
-def test_ecc_encode_compressed_point_characteristic_two():
-    with pytest.raises(NotSupportedError) as excinfo:
-        _ecc_encode_compressed_point(VALUES["ecc_private_key_char2"])
-
-    excinfo.match(r"Non-prime curves are not supported at this time")
-
-
 def test_ecc_decode_compressed_point_infinity():
     with pytest.raises(NotSupportedError) as excinfo:
         _ecc_decode_compressed_point(curve=ec.SECP384R1(), compressed_point=b"")
@@ -341,13 +334,6 @@ def test_ecc_decode_compressed_point_prime_complex(patch_ecc_curve_parameters):
         _ecc_decode_compressed_point(curve=mock_curve, compressed_point=VALUES["ecc_compressed_point"])
 
     excinfo.match(r"S not 1 :: Curve not supported at this time")
-
-
-def test_ecc_decode_compressed_point_nonprime_characteristic_two():
-    with pytest.raises(NotSupportedError) as excinfo:
-        _ecc_decode_compressed_point(curve=ec.SECT409K1(), compressed_point="\x02skdgaiuhgijudflkjsdgfkjsdflgjhsd")
-
-    excinfo.match(r"Non-prime curves are not supported at this time")
 
 
 def test_ecc_public_numbers_from_compressed_point(patch_ec, patch_ecc_decode_compressed_point):


### PR DESCRIPTION
*Issue #, if available:*
fixes https://github.com/aws/aws-encryption-sdk-python/issues/790

*Description of changes:*
The test checks if we throw an error when we get SECT409K1 curve. This is failing in downstream test of aws-lc as they don't support SECT curve. Removing these test should unblock aws lc.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

