### PR TITLE
chore: move verbose log lines from INFO to DEBUG

### DIFF
--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -482,7 +482,7 @@ class MasterKey(MasterKeyProvider):
         :rtype: aws_encryption_sdk.structures.EncryptedDataKey
         :raises IncorrectMasterKeyError: if Data Key's key provider does not match this Master Key
         """
-        _LOGGER.info("encrypting data key with encryption context: %s", encryption_context)
+        _LOGGER.debug("encrypting data key with encryption context: %s", encryption_context)
         return self._encrypt_data_key(data_key=data_key, algorithm=algorithm, encryption_context=encryption_context)
 
     @abc.abstractmethod
@@ -515,7 +515,7 @@ class MasterKey(MasterKeyProvider):
         :rtype: aws_encryption_sdk.structures.DataKey
         :raises IncorrectMasterKeyError: if Data Key's key provider does not match this Master Key
         """
-        _LOGGER.info("decrypting data key with encryption context: %s", encryption_context)
+        _LOGGER.debug("decrypting data key with encryption context: %s", encryption_context)
         self._key_check(encrypted_data_key)
         decrypted_data_key = self._decrypt_data_key(
             encrypted_data_key=encrypted_data_key, algorithm=algorithm, encryption_context=encryption_context


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

These lines are beneficial for developers working on the library itself, but not for applications which use this library. At scale, they can be quite verbose. A similar request was opened a few years ago: https://github.com/aws/aws-encryption-sdk-python/pull/494

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

