### PR TITLE
fix: validate encryption materials from cmm are compatible with kc policy

### DIFF
--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -553,6 +553,8 @@ class StreamEncryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
             request=encryption_materials_request
         )
 
+        validate_commitment_policy_on_encrypt(self.config.commitment_policy, self._encryption_materials.algorithm)
+
         if self.config.algorithm is not None and self._encryption_materials.algorithm != self.config.algorithm:
             raise ActionNotAllowedError(
                 (

--- a/test/functional/test_f_commitment.py
+++ b/test/functional/test_f_commitment.py
@@ -236,7 +236,7 @@ def test_encrypt_with_require_policy_fail_when_retrieving_invalid_cmm_materials(
     required_encrypting_client = aws_encryption_sdk.EncryptionSDKClient(
         commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
     )
-    
+ 
     provider = StaticRawMasterKeyProvider(
         wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
         encryption_key_type=EncryptionKeyType.SYMMETRIC,
@@ -249,7 +249,7 @@ def test_encrypt_with_require_policy_fail_when_retrieving_invalid_cmm_materials(
     )
     plaintext = b"Yellow Submarine"
 
-    ciphertext, _ = forbid_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
+    _, _ = forbid_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
     with pytest.raises(ActionNotAllowedError) as excinfo:
         required_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
     excinfo.match("Configuration conflict. Cannot encrypt due to .* requiring only committed messages")
@@ -264,7 +264,7 @@ def test_encrypt_with_forbid_policy_fail_when_retrieving_invalid_cmm_materials()
     required_encrypting_client = aws_encryption_sdk.EncryptionSDKClient(
         commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
     )
-    
+
     provider = StaticRawMasterKeyProvider(
         wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
         encryption_key_type=EncryptionKeyType.SYMMETRIC,
@@ -277,7 +277,7 @@ def test_encrypt_with_forbid_policy_fail_when_retrieving_invalid_cmm_materials()
     )
     plaintext = b"Yellow Submarine"
 
-    ciphertext, _ = required_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
+    _, _ = required_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
     with pytest.raises(ActionNotAllowedError) as excinfo:
         forbid_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
     excinfo.match("Configuration conflict. Cannot encrypt due to .* requiring only non-committed messages.")

--- a/test/functional/test_f_commitment.py
+++ b/test/functional/test_f_commitment.py
@@ -227,9 +227,9 @@ def test_encrypt_with_uncommitting_algorithm_require_decrypt():
     excinfo.match("Configuration conflict. Cannot decrypt due to .* requiring only committed messages")
 
 
-def test_encrypt_with_different_kc_clients_sharing_materials_yield_error():
-    """Tests that when two different client configured with CommitmentPolicy REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-    and FORBID_ENCRYPT_ALLOW_DECRYPT share encryption materials client errors out due to conflicting commitment policies."""
+def test_encrypt_with_require_policy_fail_when_retrieving_invalid_cmm_materials():
+    """Tests that when a client with a require policy shares a cache with a client with a forbid policy
+    an error gets thrown due to invalid materials retrieved from cmm"""
     forbid_encrypting_client = aws_encryption_sdk.EncryptionSDKClient(
         commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
     )
@@ -254,3 +254,30 @@ def test_encrypt_with_different_kc_clients_sharing_materials_yield_error():
         required_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
     excinfo.match("Configuration conflict. Cannot encrypt due to .* requiring only committed messages")
 
+
+def test_encrypt_with_forbid_policy_fail_when_retrieving_invalid_cmm_materials():
+    """Tests that when a client with a forbid policy shares a cache with a client with a require policy
+    an error gets thrown due to invalid materials retrieved from cmm"""
+    forbid_encrypting_client = aws_encryption_sdk.EncryptionSDKClient(
+        commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+    )
+    required_encrypting_client = aws_encryption_sdk.EncryptionSDKClient(
+        commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+    )
+    
+    provider = StaticRawMasterKeyProvider(
+        wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
+        encryption_key_type=EncryptionKeyType.SYMMETRIC,
+        key_bytes=b"\00" * 32,
+    )
+    provider.add_master_key("KeyId")
+    cache = aws_encryption_sdk.LocalCryptoMaterialsCache(capacity=10)
+    ccmm = aws_encryption_sdk.CachingCryptoMaterialsManager(
+        master_key_provider=provider, cache=cache, max_age=3600.0, max_messages_encrypted=5
+    )
+    plaintext = b"Yellow Submarine"
+
+    ciphertext, _ = required_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
+    with pytest.raises(ActionNotAllowedError) as excinfo:
+        forbid_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
+    excinfo.match("Configuration conflict. Cannot encrypt due to .* requiring only non-committed messages.")

--- a/test/functional/test_f_commitment.py
+++ b/test/functional/test_f_commitment.py
@@ -225,3 +225,33 @@ def test_encrypt_with_uncommitting_algorithm_require_decrypt():
     with pytest.raises(ActionNotAllowedError) as excinfo:
         decrypting_client.decrypt(source=ciphertext, key_provider=key_provider)
     excinfo.match("Configuration conflict. Cannot decrypt due to .* requiring only committed messages")
+
+
+def test_encrypt_with_different_kc_clients_sharing_materials_yield_error():
+    """Tests that when two different client configured with CommitmentPolicy REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+    and FORBID_ENCRYPT_ALLOW_DECRYPT share encryption materials client errors out due to conflicting commitment policies."""
+    forbid_encrypting_client = aws_encryption_sdk.EncryptionSDKClient(
+        commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+    )
+    required_encrypting_client = aws_encryption_sdk.EncryptionSDKClient(
+        commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+    )
+    
+    provider = StaticRawMasterKeyProvider(
+        wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
+        encryption_key_type=EncryptionKeyType.SYMMETRIC,
+        key_bytes=b"\00" * 32,
+    )
+    provider.add_master_key("KeyId")
+    cache = aws_encryption_sdk.LocalCryptoMaterialsCache(capacity=10)
+    ccmm = aws_encryption_sdk.CachingCryptoMaterialsManager(
+        master_key_provider=provider, cache=cache, max_age=3600.0, max_messages_encrypted=5
+    )
+    plaintext = b"Yellow Submarine"
+
+    ciphertext, _ = forbid_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
+    ciphertext2, _ = required_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
+    with pytest.raises(ActionNotAllowedError) as excinfo:
+        required_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
+    excinfo.match("Configuration conflict. Cannot encrypt due to .* requiring only committed messages")
+

--- a/test/functional/test_f_commitment.py
+++ b/test/functional/test_f_commitment.py
@@ -236,7 +236,7 @@ def test_encrypt_with_require_policy_fail_when_retrieving_invalid_cmm_materials(
     required_encrypting_client = aws_encryption_sdk.EncryptionSDKClient(
         commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
     )
- 
+
     provider = StaticRawMasterKeyProvider(
         wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
         encryption_key_type=EncryptionKeyType.SYMMETRIC,

--- a/test/functional/test_f_commitment.py
+++ b/test/functional/test_f_commitment.py
@@ -234,7 +234,7 @@ def test_encrypt_with_different_kc_clients_sharing_materials_yield_error():
         commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
     )
     required_encrypting_client = aws_encryption_sdk.EncryptionSDKClient(
-        commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+        commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
     )
     
     provider = StaticRawMasterKeyProvider(
@@ -250,7 +250,6 @@ def test_encrypt_with_different_kc_clients_sharing_materials_yield_error():
     plaintext = b"Yellow Submarine"
 
     ciphertext, _ = forbid_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
-    ciphertext2, _ = required_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
     with pytest.raises(ActionNotAllowedError) as excinfo:
         required_encrypting_client.encrypt(source=plaintext, materials_manager=ccmm)
     excinfo.match("Configuration conflict. Cannot encrypt due to .* requiring only committed messages")

--- a/tox.ini
+++ b/tox.ini
@@ -63,19 +63,19 @@ commands = pytest --basetemp={envtmpdir} -l {posargs}
 [testenv]
 passenv =
     # Identifies AWS KMS key id to use in integration tests
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID, \
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID \
     # Identifies a second AWS KMS key id to use in integration tests
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2, \
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2 \
     # Identifies AWS KMS MRK key id to use in integration tests
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1, \
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1 \
     # Identifies a related AWS KMS MRK key id to use in integration tests
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_2, \
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_2 \
     # Pass through AWS credentials
-    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, \
+    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
     # AWS Role access in CodeBuild is via the contaner URI
-    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI, \
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI \
     # Pass through AWS profile name (useful for local testing)
-    AWS_PROFILE, \
+    AWS_PROFILE \
     # Pass through custom pip config file settings
     PIP_CONFIG_FILE
 sitepackages = False

--- a/tox.ini
+++ b/tox.ini
@@ -63,19 +63,19 @@ commands = pytest --basetemp={envtmpdir} -l {posargs}
 [testenv]
 passenv =
     # Identifies AWS KMS key id to use in integration tests
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID \
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID, \
     # Identifies a second AWS KMS key id to use in integration tests
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2 \
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2, \
     # Identifies AWS KMS MRK key id to use in integration tests
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1 \
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1, \
     # Identifies a related AWS KMS MRK key id to use in integration tests
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_2 \
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_2, \
     # Pass through AWS credentials
-    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
+    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, \
     # AWS Role access in CodeBuild is via the contaner URI
-    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI \
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI, \
     # Pass through AWS profile name (useful for local testing)
-    AWS_PROFILE \
+    AWS_PROFILE, \
     # Pass through custom pip config file settings
     PIP_CONFIG_FILE
 sitepackages = False


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

