### PR TITLE
chore(ci): replace Busy Engineer's Workshop validation with in-repo install-and-import smoke test

### DIFF
--- a/codebuild/py310/decrypt_masterkey_with_js.yml
+++ b/codebuild/py310/decrypt_masterkey_with_js.yml
@@ -16,7 +16,7 @@ phases:
     runtime-versions:
       python: 3.10
     commands:
-      - n 16
+      - n 22
       # Install the Javascript ESDK run test vectors
       - npm install -g @aws-crypto/integration-node
 

--- a/codebuild/py311/decrypt_keyrings_with_js.yml
+++ b/codebuild/py311/decrypt_keyrings_with_js.yml
@@ -16,7 +16,7 @@ phases:
     runtime-versions:
       python: 3.11
     commands:
-      - n 16
+      - n 22
       # Install the Javascript ESDK run test vectors
       - npm install -g @aws-crypto/integration-node
 

--- a/codebuild/py311/decrypt_masterkey_with_js.yml
+++ b/codebuild/py311/decrypt_masterkey_with_js.yml
@@ -16,7 +16,7 @@ phases:
     runtime-versions:
       python: 3.11
     commands:
-      - n 16
+      - n 22
       # Install the Javascript ESDK run test vectors
       - npm install -g @aws-crypto/integration-node
 

--- a/codebuild/py312/decrypt_keyrings_with_js.yml
+++ b/codebuild/py312/decrypt_keyrings_with_js.yml
@@ -16,7 +16,7 @@ phases:
     runtime-versions:
       python: 3.12
     commands:
-      - n 16
+      - n 22
       # Install the Javascript ESDK run test vectors
       - npm install -g @aws-crypto/integration-node
 

--- a/codebuild/py312/decrypt_masterkey_with_js.yml
+++ b/codebuild/py312/decrypt_masterkey_with_js.yml
@@ -16,7 +16,7 @@ phases:
     runtime-versions:
       python: 3.12
     commands:
-      - n 16
+      - n 22
       # Install the Javascript ESDK run test vectors
       - npm install -g @aws-crypto/integration-node
 

--- a/codebuild/py38/decrypt_masterkey_with_js.yml
+++ b/codebuild/py38/decrypt_masterkey_with_js.yml
@@ -16,7 +16,7 @@ phases:
     runtime-versions:
       python: 3.8
     commands:
-      - n 16
+      - n 22
       # Install the Javascript ESDK run test vectors
       - npm install -g @aws-crypto/integration-node
 

--- a/codebuild/py39/decrypt_masterkey_with_js.yml
+++ b/codebuild/py39/decrypt_masterkey_with_js.yml
@@ -16,7 +16,7 @@ phases:
     runtime-versions:
       python: 3.9
     commands:
-      - n 16
+      - n 22
       # Install the Javascript ESDK run test vectors
       - npm install -g @aws-crypto/integration-node
 

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -2,25 +2,20 @@ version: 0.2
 
 phases:
   install:
-    commands:
-      - pip install "tox < 4.0"
     runtime-versions:
       python: latest
-  pre_build:
     commands:
-      - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
-      - cd busy-engineers-document-bucket/exercises/python/encryption-context-complete
-      - sed -i "s/aws_encryption_sdk/aws_encryption_sdk==$VERSION/" requirements-dev.txt
-      - pyenv install --skip-existing 3.8.12
-      - pyenv local 3.8.12
-      - pip install "tox < 4.0"
+      - python -m pip install --upgrade pip
   build:
     commands:
       - NUM_RETRIES=3
       - |
         while [ $NUM_RETRIES -gt 0 ]
         do
-          tox -re test
+          pip install "aws-encryption-sdk==$VERSION" \
+            && python -c "import aws_encryption_sdk; \
+                          from aws_encryption_sdk import StrictAwsKmsMasterKeyProvider; \
+                          print('aws-encryption-sdk', aws_encryption_sdk.__version__, 'installed and imports cleanly')"
           if [ $? -eq 0 ]; then
             break
           fi

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -18,7 +18,7 @@ phases:
         while [ $NUM_RETRIES -gt 0 ]
         do
           # basic usability smoke test
-          pip install "aws-encryption-sdk==$VERSION" && python -c "import aws_encryption_sdk; from aws_encryption_sdk import StrictAwsKmsMasterKeyProvider"
+          pip install --force-reinstall "aws-encryption-sdk==$VERSION" && python -c "import aws_encryption_sdk; from aws_encryption_sdk import StrictAwsKmsMasterKeyProvider"
           if [ $? -eq 0 ]; then
             break
           fi

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -1,21 +1,22 @@
 version: 0.2
-
 phases:
   install:
+    commands:
+      - pip install "tox < 4.0"
     runtime-versions:
       python: latest
+  pre_build:
     commands:
-      - python -m pip install --upgrade pip
+      - pyenv install --skip-existing 3.8.12
+      - pyenv local 3.8.12
+      - pip install "tox < 4.0"
   build:
     commands:
       - NUM_RETRIES=3
       - |
         while [ $NUM_RETRIES -gt 0 ]
         do
-          pip install "aws-encryption-sdk==$VERSION" \
-            && python -c "import aws_encryption_sdk; \
-                          from aws_encryption_sdk import StrictAwsKmsMasterKeyProvider; \
-                          print('aws-encryption-sdk', aws_encryption_sdk.__version__, 'installed and imports cleanly')"
+          pip install "aws-encryption-sdk==$VERSION" && python -c "import aws_encryption_sdk; from aws_encryption_sdk import StrictAwsKmsMasterKeyProvider"
           if [ $? -eq 0 ]; then
             break
           fi

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -1,4 +1,5 @@
 version: 0.2
+
 phases:
   install:
     commands:
@@ -16,6 +17,7 @@ phases:
       - |
         while [ $NUM_RETRIES -gt 0 ]
         do
+          # basic usability smoke test
           pip install "aws-encryption-sdk==$VERSION" && python -c "import aws_encryption_sdk; from aws_encryption_sdk import StrictAwsKmsMasterKeyProvider"
           if [ $? -eq 0 ]; then
             break


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Busy Engineer's Workshop is being torn down. The old validate step ran [`test_api.py`](https://github.com/aws-samples/busy-engineers-document-bucket/blob/master/exercises/python/encryption-context-complete/test/test_api.py), which is fully mocked — the only real test against the published wheel was a smoke test that it installs and imports. This PR keeps that smoke test without the workshop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
