### PR TITLE
chore: bump upstream-requirements-py311 pytest version

### DIFF
--- a/test/upstream-requirements-py311.txt
+++ b/test/upstream-requirements-py311.txt
@@ -8,13 +8,14 @@ iniconfig==2.0.0
 jmespath==1.0.1
 mock==4.0.3
 packaging==23.0
-pluggy==1.0.0
+pluggy==1.6.0
 pycparser==2.21
-pytest==7.2.0
-pytest-cov==3.0.0
+pytest==8.0.0
+pytest-cov==4.0.0
 pytest-mock==3.6.1
 python-dateutil==2.8.2
 s3transfer==0.6.0
 six==1.16.0
+tomli==2.4.1
 urllib3==1.26.18
 wrapt==1.14.1


### PR DESCRIPTION
we'd like this for cryptography's CI

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

